### PR TITLE
Add remote manifest support for portfolio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,66 @@ VITE_MANIFEST_URL="https://raw.githubusercontent.com/<user>/<repo>/main/content/
 
 Because the SPA fetches the manifest at runtime, any change pushed through Tina (or another CMS) is immediately reflected in production without recompiling the WebAssembly module.
 
+### 4. Pipe the manifest straight from Sanity
+
+If you prefer Sanity over a Git-based CMS, the runtime store can query the Content Lake directly. Set the following environment variables before `npm run dev`/`npm run build`:
+
+```bash
+VITE_SANITY_PROJECT_ID="your-project-id"
+VITE_SANITY_DATASET="production"      # or your dataset name
+VITE_SANITY_API_VERSION="2023-10-06"   # optional; defaults to 2023-10-06
+# Optional advanced knobs
+# VITE_SANITY_QUERY="*[_type == \"portfolioManifest\"][0]{ ... }"
+# VITE_SANITY_QUERY_PARAMS='{"slug": "main"}'
+```
+
+With `VITE_SANITY_PROJECT_ID` and `VITE_SANITY_DATASET` defined, SpicyOS skips the JSON fetch and instead runs a GROQ query. The default query expects a document shaped like the JSON manifest (root metadata, `desktop[]`, `folders[]` w/ nested `entries`). Customize it by overriding `VITE_SANITY_QUERY`. All results run through the same normalizer as the static manifest, so links, shortcuts, and nested folders behave exactly like built-in files.
+
+#### Example schema
+
+Drop these schema snippets into `sanity/schemaTypes` to mirror the manifest:
+
+```ts
+import { defineField, defineType } from 'sanity';
+
+export const portfolioEntry = defineType({
+  name: 'portfolioEntry',
+  type: 'object',
+  fields: [
+    defineField({ name: 'name', type: 'string', validation: (Rule) => Rule.required() }),
+    defineField({ name: 'extension', type: 'string' }),
+    defineField({ name: 'kind', type: 'string', options: { list: ['file', 'link', 'shortcut'] } }),
+    defineField({ name: 'contentMode', type: 'string', options: { list: ['url', 'data'] } }),
+    defineField({ name: 'content', type: 'url' }),
+    defineField({ name: 'asset', type: 'file' }),
+    defineField({ name: 'tags', type: 'array', of: [{ type: 'string' }] }),
+    defineField({ name: 'meta', type: 'object' }),
+  ],
+});
+
+export const remoteFolder = defineType({
+  name: 'remoteFolder',
+  type: 'object',
+  fields: [
+    defineField({ name: 'name', type: 'string', validation: (Rule) => Rule.required() }),
+    defineField({ name: 'entries', type: 'array', of: [{ type: 'portfolioEntry' }, { type: 'remoteFolder' }] }),
+  ],
+});
+
+export default defineType({
+  name: 'portfolioManifest',
+  title: 'Portfolio Manifest',
+  type: 'document',
+  fields: [
+    defineField({ name: 'root', type: 'object', fields: [defineField({ name: 'name', type: 'string' })] }),
+    defineField({ name: 'desktop', type: 'array', of: [{ type: 'portfolioEntry' }] }),
+    defineField({ name: 'folders', type: 'array', of: [{ type: 'remoteFolder' }] }),
+  ],
+});
+```
+
+Publish new entries through Sanity Studio and reload the site—the manifest refreshes instantly without touching the repo or the WebAssembly build.
+
 ---
 
 If by some miracle you're interested in contributing, open an issue or reach out. I’ll walk you through it!

--- a/README.md
+++ b/README.md
@@ -121,6 +121,58 @@ This will:
 
 ---
 
+## 🗃️ Remote manifest + CMS hooks
+
+The faux filesystem that powers the desktop is still compiled into WebAssembly, but you no longer have to rebuild it whenever you add new portfolio pieces. SpicyOS can now load **runtime data** from a JSON manifest and merge those entries directly into the Desktop and File Manager.
+
+### 1. Point the app at a manifest
+
+- Out of the box, the app looks for `/portfolio-manifest.json` (see `public/portfolio-manifest.json`).
+- Override the location by setting `VITE_MANIFEST_URL` before building/deploying:
+
+```bash
+VITE_MANIFEST_URL="https://raw.githubusercontent.com/<user>/<repo>/main/content/portfolio-manifest.json" npm run build
+```
+
+### 2. Manifest schema
+
+```jsonc
+{
+  "version": 1,
+  "root": { "name": "Remote Files" },
+  "desktop": [
+    { "id": "resume", "name": "Resume", "extension": "PDF", "kind": "link", "content": "https://.../resume.pdf" },
+    { "id": "poster", "name": "Poster.png", "extension": "PNG", "contentMode": "url", "content": "https://cdn.../poster.png" }
+  ],
+  "folders": [
+    {
+      "id": "portfolio",
+      "name": "Portfolio",
+      "entries": [
+        { "id": "case-study", "name": "Case Study", "extension": "MD", "contentMode": "url", "content": "https://.../case-study.md" },
+        { "id": "demo", "name": "Live Demo", "kind": "link", "content": "https://..." }
+      ]
+    }
+  ]
+}
+```
+
+- `desktop` entries appear as icons on the desktop.
+- `folders` populate a new **Remote Files** entry inside the File Manager sidebar (you can nest folders via `entries`).
+- Set `kind: "link"` (or `launch: "browser"`) to open a URL in the in-app browser.
+- Use `contentMode: "url"` whenever the `content` points at an external file; otherwise the viewer assumes a Base64 data URI.
+
+### 3. Hook it up to Tina CMS (or any Git-based CMS)
+
+1. Create a content repository (or a `content/` folder in this repo) that contains `portfolio-manifest.json` plus your uploads.
+2. Configure [Tina](https://tina.io/) to edit that JSON file (a single collection with one document works well) and authorize it against GitHub. Every publish action commits the updated manifest + assets.
+3. Deploy Tina somewhere (Vercel/Netlify). Update `VITE_MANIFEST_URL` to point at the *raw* manifest (`https://raw.githubusercontent.com/.../portfolio-manifest.json`) or at a signed URL from your storage bucket.
+4. Optional: host large binaries (images, PDFs, audio) on object storage (S3, Supabase, Cloudinary). Paste the resulting URLs into the manifest; no rebuild is necessary and the desktop/manager will refresh on reload.
+
+Because the SPA fetches the manifest at runtime, any change pushed through Tina (or another CMS) is immediately reflected in production without recompiling the WebAssembly module.
+
+---
+
 If by some miracle you're interested in contributing, open an issue or reach out. I’ll walk you through it!
 
 

--- a/public/portfolio-manifest.json
+++ b/public/portfolio-manifest.json
@@ -1,0 +1,58 @@
+{
+  "version": 1,
+  "root": {
+    "id": "remote-root",
+    "name": "Remote Files"
+  },
+  "desktop": [
+    {
+      "id": "live-resume",
+      "name": "Resume (Live)",
+      "extension": "PDF",
+      "kind": "link",
+      "content": "https://example.com/resume.pdf"
+    },
+    {
+      "id": "case-study",
+      "name": "Case Study",
+      "extension": "MD",
+      "contentMode": "url",
+      "content": "https://raw.githubusercontent.com/example/portfolio-content/main/case-study.md"
+    }
+  ],
+  "folders": [
+    {
+      "id": "portfolio",
+      "name": "Portfolio",
+      "entries": [
+        {
+          "id": "poster",
+          "name": "2024 Poster.png",
+          "extension": "PNG",
+          "contentMode": "url",
+          "content": "https://example.com/uploads/poster.png"
+        },
+        {
+          "id": "demo",
+          "name": "Live Demo",
+          "extension": "URL",
+          "kind": "link",
+          "content": "https://example.com/work/demo"
+        },
+        {
+          "id": "nested-folder",
+          "name": "In Progress",
+          "entries": [
+            {
+              "id": "draft",
+              "name": "Draft Notes",
+              "extension": "TXT",
+              "contentMode": "url",
+              "content": "https://raw.githubusercontent.com/example/portfolio-content/main/drafts/notes.txt"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/desktop/Desktop.vue
+++ b/src/components/desktop/Desktop.vue
@@ -20,9 +20,9 @@
         />
     </template>
     <div id="filespace">
-      <div 
-            v-for="item in desktopContents" 
-            :key="item.name" 
+      <div
+            v-for="item in desktopContents"
+            :key="item.id ?? item.name"
             class="file-item "
             :class="{'h-35 w-35': isMobile, 'h-40 w-40': !isMobile}"
             @dblclick="handleFileOpen(item)"
@@ -48,7 +48,7 @@ import MinimizedFileBar from '@/components/desktop/MinimizedFileBar.vue';
 
 import { createLoader } from '@/components/utilities/simulateLoading';
 
-import { ref, toRaw, defineAsyncComponent, reactive, provide, onMounted } from 'vue';
+import { ref, toRaw, defineAsyncComponent, reactive, provide, onMounted, computed } from 'vue';
 
 const ContentWindow = defineAsyncComponent(() => import("@/components/windows/ContentWindow.vue"));
 const emit = defineEmits(['initialized', 'progress'])
@@ -59,16 +59,28 @@ import makeDirectoryItems from '@/components/utilities/makeDirectoryItems';
 import { makeFileItems } from '@/components/utilities/makeFileItems';
 import { openFile } from '@/components/utilities/openFile';
 import { useIsMobile } from "@/components/utilities/useIsMobile";
+import { useFilesStore } from '@/components/stores/files';
 
 const {isMobile} = useIsMobile()
 const windowRefs = reactive({});
 
 provide('windowRefs', windowRefs);
-const desktopContents = ref([]);
+const systemDesktopContents = ref([]);
 const appsStore = useAppsStore();
 const { openApps, openFiles, isAppOpen } = storeToRefs(appsStore);
 const fmId = 'file_manager'
 const browserId = 'browser'
+
+const filesStore = useFilesStore();
+const { desktopManifestItems } = storeToRefs(filesStore);
+
+const desktopContents = computed(() => {
+  const base = systemDesktopContents.value ?? [];
+  if (!desktopManifestItems.value.length) {
+    return base;
+  }
+  return base.concat(desktopManifestItems.value);
+});
 
 const loader = createLoader(2, p => emit('progress', p))
 
@@ -128,12 +140,16 @@ onMounted(() => {
   SystemModule.onRuntimeInitialized = () => {
     loader.checkpoint()
     console.log("SystemModule is fully initialized.");
-    desktopContents.value = getDesktopContents(); 
+    systemDesktopContents.value = getDesktopContents();
     loader.checkpoint()
   };
 
   loader.done.then(() => emit('initialized'))
-  
+
+})
+
+onMounted(() => {
+  filesStore.loadManifest();
 })
 
 

--- a/src/components/desktop/Desktop.vue
+++ b/src/components/desktop/Desktop.vue
@@ -75,11 +75,11 @@ const filesStore = useFilesStore();
 const { desktopManifestItems } = storeToRefs(filesStore);
 
 const desktopContents = computed(() => {
-  const base = systemDesktopContents.value ?? [];
-  if (!desktopManifestItems.value.length) {
-    return base;
+  const manifestItems = desktopManifestItems.value ?? [];
+  if (manifestItems.length) {
+    return manifestItems;
   }
-  return base.concat(desktopManifestItems.value);
+  return systemDesktopContents.value ?? [];
 });
 
 const loader = createLoader(2, p => emit('progress', p))

--- a/src/components/desktop/MinimizedFileBar.vue
+++ b/src/components/desktop/MinimizedFileBar.vue
@@ -13,13 +13,14 @@
     w-20 left-0 flex flex-col items-center justify-center">
 
       
-      <div 
+      <div
         v-for="file in minimizedFiles"
-        :id="`filewin-${file.item.object.$$.ptr}`"
+        :key="file.identity"
+        :id="`filewin-${file.identity}`"
         class="w-full h-16 relative bg-white/10 border-b border-white/20"
         ref="minimizedIcon"
       >
-        <span class="text-xs text-center w-full block">{{ file.item.object.$$.ptr }}</span>
+        <span class="text-xs text-center w-full block">{{ file.item.name }}</span>
       </div>
       
   </div>

--- a/src/components/stores/apps.js
+++ b/src/components/stores/apps.js
@@ -3,6 +3,19 @@
 import { defineStore } from 'pinia';
 import { useIsMobile } from '@/components/utilities/useIsMobile';
 
+const getItemIdentity = (item) => {
+  if (!item) {
+    return null;
+  }
+  if (item.object?.$$?.ptr !== undefined) {
+    return `ptr-${item.object.$$.ptr}`;
+  }
+  if (item.id) {
+    return `id-${item.id}`;
+  }
+  return `name-${item.name}`;
+};
+
 function getIsMobile() {
   const { isMobile } = useIsMobile();
   return isMobile;
@@ -70,37 +83,50 @@ export const useAppsStore = defineStore('apps', {
 
     // Files
     getFilezIndex(item) {
-      return this.openFiles.find(file => file.item === item).zIndex;
+      const identity = getItemIdentity(item);
+      return this.openFiles.find(file => file.identity === identity)?.zIndex ?? 0;
     },
     isFileOpen(item) {
-      return this.openFiles.some(file => file.item.object.$$.ptr === item.object.$$.ptr);
+      const identity = getItemIdentity(item);
+      return this.openFiles.some(file => file.identity === identity);
     },
-    
+
     isFileMaximized(item) {
-      return this.openFiles.find(file => file.item === item).maximized;
+      const identity = getItemIdentity(item);
+      return this.openFiles.find(file => file.identity === identity)?.maximized ?? false;
     },
     isFileMinimized(item) {
-      return this.openFiles.find(file => file.item === item).minimized;
+      const identity = getItemIdentity(item);
+      return this.openFiles.find(file => file.identity === identity)?.minimized ?? false;
     },
     openFile(item) {
-      if (!this.isFileOpen(item)) {
-        this.openFiles.push({ item, zIndex: ++this.zIndexCounter, maximized: false, minimized: false});
+      const identity = getItemIdentity(item);
+      if (!this.openFiles.some(file => file.identity === identity)) {
+        this.openFiles.push({ identity, item, zIndex: ++this.zIndexCounter, maximized: false, minimized: false});
       }
-      
+
     },
     setFileMaximize(item, bool) {
-      this.openFiles.find(file => file.item === item).maximized = bool; 
+      const identity = getItemIdentity(item);
+      const openFile = this.openFiles.find(file => file.identity === identity);
+      if (openFile) openFile.maximized = bool;
     },
     setFileMinimize(item, bool) {
-      this.openFiles.find(file => file.item === item).minimized = bool; 
+      const identity = getItemIdentity(item);
+      const openFile = this.openFiles.find(file => file.identity === identity);
+      if (openFile) openFile.minimized = bool;
     },
     bringFileToFront(item) {
-      const file = this.openFiles.find(file => file.item === item);
+      const identity = getItemIdentity(item);
+      const file = this.openFiles.find(file => file.identity === identity);
       if (file) file.zIndex = ++this.zIndexCounter;
     },
     closeFile(item) {
-      const fileIndex = this.openFiles.findIndex(file => file.item === item);
-      this.openFiles.splice(fileIndex, 1);
-    }, 
+      const identity = getItemIdentity(item);
+      const fileIndex = this.openFiles.findIndex(file => file.identity === identity);
+      if (fileIndex >= 0) {
+        this.openFiles.splice(fileIndex, 1);
+      }
+    },
   },
 });

--- a/src/components/stores/files.js
+++ b/src/components/stores/files.js
@@ -1,0 +1,132 @@
+import { defineStore } from 'pinia';
+
+const defaultManifestUrl = import.meta.env.VITE_MANIFEST_URL ?? '/portfolio-manifest.json';
+
+const randomId = () => {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `id-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const slugify = (value) =>
+  value
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-');
+
+const normalizeFileEntry = (entry = {}, parentSegments = []) => {
+  const safeName = entry.name ?? entry.label ?? 'Untitled';
+  const id = entry.id ?? slugify([...parentSegments, safeName].join('-')) ?? randomId();
+  const contentMode = entry.contentMode ?? entry.content_mode ?? entry.mode ?? (entry.url ? 'url' : 'data');
+  const launchMode = entry.launch ?? entry.viewer;
+  const content = entry.content ?? entry.url ?? '';
+  const resolvedContentMode = contentMode === 'data' && /^https?:\/\//i.test(content)
+    ? 'url'
+    : contentMode;
+
+  return {
+    id,
+    type: 'f',
+    name: safeName,
+    exten: entry.extension ?? entry.ext ?? '',
+    content,
+    contentMode: resolvedContentMode,
+    is_shortcut: entry.kind === 'shortcut',
+    is_link: entry.kind === 'link' || launchMode === 'browser',
+    source: 'manifest',
+    tags: entry.tags ?? [],
+    meta: entry.meta ?? {},
+  };
+};
+
+const normalizeFolder = (folder = {}, parentSegments = []) => {
+  const folderName = folder.name ?? 'Folder';
+  const id = folder.id ?? slugify([...parentSegments, folderName].join('-')) ?? randomId();
+  const nextSegments = [...parentSegments, folderName];
+  const entries = Array.isArray(folder.entries)
+    ? folder.entries.map((entry) =>
+        entry.entries || entry.kind === 'folder'
+          ? normalizeFolder(entry, nextSegments)
+          : normalizeFileEntry(entry, nextSegments),
+      )
+    : [];
+
+  return {
+    id,
+    type: 'd',
+    name: folderName,
+    source: 'manifest',
+    entries,
+  };
+};
+
+const normalizeManifest = (payload = {}) => {
+  const rootConfig = payload.root ?? {};
+  const desktopEntries = Array.isArray(payload.desktop)
+    ? payload.desktop.map((entry) => normalizeFileEntry(entry, ['desktop']))
+    : [];
+
+  const remoteFolders = Array.isArray(payload.folders)
+    ? payload.folders.map((folder) => normalizeFolder(folder, [rootConfig.name ?? 'remote']))
+    : [];
+
+  return {
+    desktop: desktopEntries,
+    remoteRoot: {
+      id: rootConfig.id ?? 'remote-root',
+      name: rootConfig.name ?? 'Remote Files',
+      type: 'd',
+      source: 'manifest',
+      entries: remoteFolders,
+    },
+  };
+};
+
+export const useFilesStore = defineStore('files', {
+  state: () => ({
+    status: 'idle',
+    error: null,
+    manifest: null,
+    manifestUrl: defaultManifestUrl,
+  }),
+  getters: {
+    desktopManifestItems: (state) => state.manifest?.desktop ?? [],
+    remoteRootFolder: (state) => state.manifest?.remoteRoot ?? null,
+    hasManifest: (state) => Boolean(state.manifest),
+    remoteRootName: (state) => state.manifest?.remoteRoot?.name ?? 'Remote Files',
+  },
+  actions: {
+    async loadManifest(url) {
+      const targetUrl = url ?? this.manifestUrl ?? defaultManifestUrl;
+      if (this.status === 'loading' && targetUrl === this.manifestUrl) {
+        return;
+      }
+
+      if (this.status === 'ready' && this.manifest && targetUrl === this.manifestUrl) {
+        return;
+      }
+
+      this.status = 'loading';
+      this.error = null;
+
+      try {
+        const response = await fetch(targetUrl, { cache: 'no-cache' });
+        if (!response.ok) {
+          throw new Error(`Unable to load manifest (HTTP ${response.status})`);
+        }
+        const payload = await response.json();
+        this.manifestUrl = targetUrl;
+        this.manifest = normalizeManifest(payload);
+        this.status = 'ready';
+      } catch (error) {
+        console.error('[filesStore] Failed to load manifest', error);
+        this.error = error instanceof Error ? error.message : 'Unknown manifest error';
+        this.status = 'error';
+        this.manifest = null;
+      }
+    },
+  },
+});
+

--- a/src/components/stores/files.js
+++ b/src/components/stores/files.js
@@ -2,6 +2,97 @@ import { defineStore } from 'pinia';
 
 const defaultManifestUrl = import.meta.env.VITE_MANIFEST_URL ?? '/portfolio-manifest.json';
 
+const sanityConfig = {
+  projectId: import.meta.env.VITE_SANITY_PROJECT_ID,
+  dataset: import.meta.env.VITE_SANITY_DATASET ?? 'production',
+  apiVersion: import.meta.env.VITE_SANITY_API_VERSION ?? '2023-10-06',
+  query:
+    import.meta.env.VITE_SANITY_QUERY ??
+    `*[_type == "portfolioManifest"][0]{
+      root,
+      desktop[]{
+        "id": coalesce(id, _key),
+        name,
+        extension,
+        kind,
+        content,
+        contentMode,
+        launch,
+        viewer,
+        url,
+        fileUrl,
+        href,
+        assetUrl,
+        "asset": asset->{url},
+        tags,
+        meta
+      },
+      folders[]{
+        "id": coalesce(id, _key),
+        name,
+        entries[]{
+          ...,
+          "id": coalesce(id, _key)
+        }
+      }
+    }`,
+  token: import.meta.env.VITE_SANITY_TOKEN,
+  params: import.meta.env.VITE_SANITY_QUERY_PARAMS,
+};
+
+const hasSanityConfig = Boolean(sanityConfig.projectId && sanityConfig.dataset);
+
+const parseSanityParams = () => {
+  if (!sanityConfig.params) {
+    return null;
+  }
+  try {
+    return JSON.parse(sanityConfig.params);
+  } catch (error) {
+    console.warn('[filesStore] Unable to parse VITE_SANITY_QUERY_PARAMS', error);
+    return null;
+  }
+};
+
+const fetchSanityManifest = async () => {
+  const { projectId, dataset, apiVersion, query, token } = sanityConfig;
+  const params = parseSanityParams();
+  const encodedQuery = encodeURIComponent(query.trim());
+  const encodedParams = params ? `&${new URLSearchParams(Object.entries(params)).toString()}` : '';
+  const endpoint = `https://${projectId}.api.sanity.io/${apiVersion}/data/query/${dataset}?query=${encodedQuery}${encodedParams}`;
+
+  const response = await fetch(endpoint, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Sanity query failed (HTTP ${response.status})`);
+  }
+
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(payload.error.description ?? 'Sanity query returned an error');
+  }
+
+  if (!payload.result) {
+    throw new Error('Sanity response did not include a result');
+  }
+
+  if (Array.isArray(payload.result)) {
+    return payload.result[0] ?? {};
+  }
+
+  return payload.result;
+};
+
+const fetchManifestFromUrl = async (targetUrl) => {
+  const response = await fetch(targetUrl, { cache: 'no-cache' });
+  if (!response.ok) {
+    throw new Error(`Unable to load manifest (HTTP ${response.status})`);
+  }
+  return response.json();
+};
+
 const randomId = () => {
   if (globalThis.crypto?.randomUUID) {
     return globalThis.crypto.randomUUID();
@@ -19,12 +110,19 @@ const slugify = (value) =>
 const normalizeFileEntry = (entry = {}, parentSegments = []) => {
   const safeName = entry.name ?? entry.label ?? 'Untitled';
   const id = entry.id ?? slugify([...parentSegments, safeName].join('-')) ?? randomId();
-  const contentMode = entry.contentMode ?? entry.content_mode ?? entry.mode ?? (entry.url ? 'url' : 'data');
+  const explicitMode = entry.contentMode ?? entry.content_mode ?? entry.mode;
   const launchMode = entry.launch ?? entry.viewer;
-  const content = entry.content ?? entry.url ?? '';
-  const resolvedContentMode = contentMode === 'data' && /^https?:\/\//i.test(content)
-    ? 'url'
-    : contentMode;
+  const content =
+    entry.content ??
+    entry.url ??
+    entry.fileUrl ??
+    entry.href ??
+    entry.assetUrl ??
+    entry.asset?.url ??
+    '';
+  const resolvedContentMode =
+    explicitMode ??
+    (/^https?:\/\//i.test(content) ? 'url' : 'data');
 
   return {
     id,
@@ -100,11 +198,13 @@ export const useFilesStore = defineStore('files', {
   actions: {
     async loadManifest(url) {
       const targetUrl = url ?? this.manifestUrl ?? defaultManifestUrl;
-      if (this.status === 'loading' && targetUrl === this.manifestUrl) {
+      const sourceKey = hasSanityConfig ? 'sanity' : targetUrl;
+
+      if (this.status === 'loading' && sourceKey === this.manifestUrl) {
         return;
       }
 
-      if (this.status === 'ready' && this.manifest && targetUrl === this.manifestUrl) {
+      if (this.status === 'ready' && this.manifest && sourceKey === this.manifestUrl) {
         return;
       }
 
@@ -112,12 +212,11 @@ export const useFilesStore = defineStore('files', {
       this.error = null;
 
       try {
-        const response = await fetch(targetUrl, { cache: 'no-cache' });
-        if (!response.ok) {
-          throw new Error(`Unable to load manifest (HTTP ${response.status})`);
-        }
-        const payload = await response.json();
-        this.manifestUrl = targetUrl;
+        const payload = hasSanityConfig
+          ? await fetchSanityManifest()
+          : await fetchManifestFromUrl(targetUrl);
+
+        this.manifestUrl = sourceKey;
         this.manifest = normalizeManifest(payload);
         this.status = 'ready';
       } catch (error) {

--- a/src/components/utilities/makeDirectoryItems.js
+++ b/src/components/utilities/makeDirectoryItems.js
@@ -1,9 +1,17 @@
-export default function makeDirectoryItems(directories) {
-    const contentsList = [];
-    for (let i = 0; i < directories.size(); i++) {
-    const d = directories.get(i);
-    contentsList.push({ object: d, type: "d", name: d.name});
-    }
+const randomId = () => {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `dir-${Math.random().toString(36).slice(2, 10)}`;
+};
 
-    return contentsList;
+export default function makeDirectoryItems(directories) {
+  const contentsList = [];
+  for (let i = 0; i < directories.size(); i++) {
+    const d = directories.get(i);
+    const id = d?.$$?.ptr ?? randomId();
+    contentsList.push({ object: d, type: 'd', name: d.name, id: `dir-${id}` });
+  }
+
+  return contentsList;
 }

--- a/src/components/utilities/makeFileItems.js
+++ b/src/components/utilities/makeFileItems.js
@@ -1,35 +1,34 @@
-export function makeFileItems (files) {
-    const contentsList = [];
-    for (let i = 0; i < files.size(); i++) {
-        const f = files.get(i);
-        contentsList.push({ 
-            object: f, 
-            type: "f", 
-            name: f.name, 
-            exten: f.extension_abbr, 
-            content: f.content, 
-            is_shortcut: f.is_shortcut,
-            is_link: f.is_link
-        });
-
-    }
-
-    return contentsList;
+const randomId = () => {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `file-${Math.random().toString(36).slice(2, 10)}`;
 };
 
-export function makeFileItem (f) {
-   
-    const file_object = { 
-        object: f, 
-        type: "f", 
-        name: f.name, 
-        exten: f.extension_abbr, 
-        content: f.content, 
-        is_shortcut: f.is_shortcut,
-        is_link: f.is_link
-    };
+const buildFileObject = (f) => ({
+  object: f,
+  type: 'f',
+  name: f.name,
+  exten: f.extension_abbr,
+  content: f.content,
+  contentMode: 'data',
+  is_shortcut: f.is_shortcut,
+  is_link: f.is_link,
+  id: `file-${f?.$$?.ptr ?? randomId()}`,
+});
 
-    return file_object;
+export function makeFileItems(files) {
+  const contentsList = [];
+  for (let i = 0; i < files.size(); i++) {
+    const f = files.get(i);
+    contentsList.push(buildFileObject(f));
+  }
+
+  return contentsList;
+};
+
+export function makeFileItem(f) {
+  return buildFileObject(f);
 };
 
 

--- a/src/components/views/BrowserView.vue
+++ b/src/components/views/BrowserView.vue
@@ -51,9 +51,19 @@ const props = defineProps({
 const currentUrl = ref("https://centari2013.github.io/SoundRoom");
 const iframe = useTemplateRef('iframe')
 
-if (props.args) {
-  const propLink = extractAndDecodeBase64(props.args.url)
-  currentUrl.value = propLink;
+const decodeUrl = (value) => {
+  if (!value) {
+    return null;
+  }
+  if (/^https?:\/\//i.test(value)) {
+    return value;
+  }
+  const decoded = extractAndDecodeBase64(value);
+  return decoded || value;
+};
+
+if (props.args?.url) {
+  currentUrl.value = decodeUrl(props.args.url) ?? currentUrl.value;
 }
 
 const openInNewTab = () =>{

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -8,8 +8,8 @@
           v-for="dir in sidebarDirs"
           :key="dir.name"
           class="sidebar-item"
-          :class="{ 'selected-sidebar-item': activePtr === dir.ptr }"
-          @click="chdir(toRaw(dir.ptr))"
+          :class="{ 'selected-sidebar-item': isActiveSidebar(dir) }"
+          @click="handleSidebarClick(dir)"
         >
           {{ dir.name }}
         </li>
@@ -41,11 +41,11 @@
       <div class="file-grid-container">
         <!-- Responsive Grid that Auto-adjusts -->
         <div class="file-grid">
-          <div 
-            v-for="item in contents" 
-            :key="item.name" 
+          <div
+            v-for="item in contents"
+            :key="item.id ?? item.name"
             class="file-item"
-            @dblclick="item.type === 'd' ? chdir(toRaw(item.object)) : openFile(item)"
+            @dblclick="handleFileDoubleClick(item)"
           >
             <Icon v-if="item.type === 'd'" :image="'directory'" class="d"/>
             <Icon v-else-if="item.type === 'f'" :image="'file'" />
@@ -62,9 +62,11 @@
 
 <script>
 import "@/assets/js/terminal/system";
-import { ref, onMounted, toRaw } from "vue";
+import { computed, ref, onMounted, toRaw, watch } from "vue";
 import Icon from "@/components/desktop/Icon.vue";
 import { useAppsStore } from "@/components/stores/apps";
+import { useFilesStore } from '@/components/stores/files';
+import { storeToRefs } from 'pinia';
 import makeDirectoryItems from "@/components/utilities/makeDirectoryItems";
 import {makeFileItems} from "@/components/utilities/makeFileItems";
 import { openFile } from '@/components/utilities/openFile'
@@ -73,56 +75,199 @@ export default {
   components: { Icon },
 setup() {
     // Reactive states
-    const contents = ref([]);
-    const disableBack = ref(true);
-    const disableForward = ref(true);
+    const fsContents = ref([]);
     const directoryTitle = ref("Directory");
     const activePtr = ref(null);
+    const useManifest = ref(false);
+    const manifestHistory = ref([[]]);
+    const manifestHistoryIndex = ref(0);
+    const filesStore = useFilesStore();
+    const { remoteRootFolder, hasManifest, remoteRootName } = storeToRefs(filesStore);
+    const appsStore = useAppsStore();
+    const browserId = 'browser';
 
     // Fetch directory contents
     const getDirContents = () => {
+      if (typeof SystemModule === 'undefined' || !SystemModule.get_cur_fs_dir) {
+        return [];
+      }
       const files = SystemModule.list_files(SystemModule.get_cur_fs_dir());
       const directories = SystemModule.list_directories(SystemModule.get_cur_fs_dir());
       directoryTitle.value = SystemModule.get_cur_fs_dir().name;
 
-      //const contentsList = [];
       const contentsList = makeDirectoryItems(directories).concat(makeFileItems(files));
-      
+
       contentsList.sort((a, b) => a.name.localeCompare(b.name));
       return contentsList;
     };
 
+    const manifestPath = computed(() => manifestHistory.value[manifestHistoryIndex.value] ?? []);
+
+    const resolveManifestNode = (path) => {
+      if (!remoteRootFolder.value) {
+        return null;
+      }
+      let node = remoteRootFolder.value;
+      for (const segment of path) {
+        node = node?.entries?.find(entry => entry.id === segment);
+        if (!node) {
+          return null;
+        }
+      }
+      return node;
+    };
+
+    const manifestContents = computed(() => {
+      if (!remoteRootFolder.value) {
+        return [];
+      }
+      const node = resolveManifestNode(manifestPath.value);
+      if (!node) {
+        return [];
+      }
+      return node.type === 'd' ? node.entries ?? [] : [];
+    });
+
+    const contents = computed(() => useManifest.value ? manifestContents.value : fsContents.value);
+
     // Navigation methods
     const chdir = (item) => {
+      if (typeof SystemModule === 'undefined' || !SystemModule.cd) {
+        return;
+      }
+      useManifest.value = false;
       SystemModule.cd(item);
       activePtr.value = item; // <-- track current ptr
-      contents.value = getDirContents();
-      syncButtonState();
+      fsContents.value = getDirContents();
+    };
+
+    const enterManifestDirectory = (dirId) => {
+      const nextHistory = manifestHistory.value.slice(0, manifestHistoryIndex.value + 1);
+      nextHistory.push([...manifestPath.value, dirId]);
+      manifestHistory.value = nextHistory;
+      manifestHistoryIndex.value = nextHistory.length - 1;
     };
 
     const back = () => {
+      if (useManifest.value) {
+        if (manifestHistoryIndex.value > 0) {
+          manifestHistoryIndex.value -= 1;
+        }
+        return;
+      }
+      if (typeof SystemModule === 'undefined' || !SystemModule.cd_back) {
+        return;
+      }
       SystemModule.cd_back();
-      contents.value = getDirContents();
-      syncButtonState();
+      fsContents.value = getDirContents();
     };
 
     const forward = () => {
+      if (useManifest.value) {
+        if (manifestHistoryIndex.value < manifestHistory.value.length - 1) {
+          manifestHistoryIndex.value += 1;
+        }
+        return;
+      }
+      if (typeof SystemModule === 'undefined' || !SystemModule.cd_forward) {
+        return;
+      }
       SystemModule.cd_forward();
-      contents.value = getDirContents();
-      syncButtonState();
+      fsContents.value = getDirContents();
     };
 
-    // Sync button states
-    const syncButtonState = () => {
-      disableBack.value = SystemModule.back_history_empty();
-      disableForward.value = SystemModule.forward_history_empty();
+    const disableBack = computed(() => {
+      if (useManifest.value) {
+        return manifestHistoryIndex.value === 0;
+      }
+      if (typeof SystemModule === 'undefined' || !SystemModule.back_history_empty) {
+        return true;
+      }
+      return SystemModule.back_history_empty();
+    });
+
+    const disableForward = computed(() => {
+      if (useManifest.value) {
+        return manifestHistoryIndex.value >= manifestHistory.value.length - 1;
+      }
+      if (typeof SystemModule === 'undefined' || !SystemModule.forward_history_empty) {
+        return true;
+      }
+      return SystemModule.forward_history_empty();
+    });
+
+    const updateManifestTitle = () => {
+      if (!remoteRootFolder.value) {
+        directoryTitle.value = 'Remote Files';
+        return;
+      }
+      const parts = [remoteRootFolder.value.name];
+      let node = remoteRootFolder.value;
+      manifestPath.value.forEach((segment) => {
+        const next = node.entries?.find(entry => entry.id === segment);
+        if (next) {
+          parts.push(next.name);
+          if (next.type === 'd') {
+            node = next;
+          }
+        }
+      });
+      directoryTitle.value = parts.join(' / ');
     };
 
-    // On mounted, initialize contents and button states
+    watch([useManifest, manifestPath, remoteRootFolder], () => {
+      if (useManifest.value) {
+        updateManifestTitle();
+      }
+    });
+
+    const handleFileDoubleClick = (item) => {
+      if (item.type === 'd') {
+        if (item.source === 'manifest') {
+          enterManifestDirectory(item.id);
+        } else {
+          chdir(toRaw(item.object));
+        }
+        return;
+      }
+
+      if (item.is_link) {
+        appsStore.openApp(browserId, { url: item.content });
+        return;
+      }
+
+      openFile(item);
+    };
+
+    const handleSidebarClick = (dir) => {
+      if (dir.isManifest) {
+        if (!remoteRootFolder.value) {
+          return;
+        }
+        useManifest.value = true;
+        manifestHistory.value = [[]];
+        manifestHistoryIndex.value = 0;
+        updateManifestTitle();
+      } else {
+        useManifest.value = false;
+        chdir(toRaw(dir.ptr));
+      }
+    };
+
+    const isActiveSidebar = (dir) => {
+      if (dir.isManifest) {
+        return useManifest.value;
+      }
+      return !useManifest.value && activePtr.value === dir.ptr;
+    };
+
+    // On mounted, initialize contents
     onMounted(() => {
-      contents.value = getDirContents();
-      activePtr.value = SystemModule.get_cur_fs_dir(); // Set current dir on load
-      syncButtonState();
+      fsContents.value = getDirContents();
+      if (typeof SystemModule !== 'undefined' && SystemModule.get_cur_fs_dir) {
+        activePtr.value = SystemModule.get_cur_fs_dir();
+      }
+      filesStore.loadManifest();
     });
 
 
@@ -133,14 +278,22 @@ setup() {
     const desktop_ptr = SystemModule.get_desktop_dir_ptr();
     const root_ptr = SystemModule.get_root_dir_ptr();
 
-    const sidebarDirs = ref([
-    { name: "Home", ptr: home_ptr },
-    { name: "Desktop", ptr: desktop_ptr },
-    { name: "Downloads", ptr: downloads_ptr },
-    { name: "Documents", ptr: documents_ptr },
-    { name: "Pictures", ptr: pictures_ptr },
-    { name: "Root", ptr: root_ptr }
-    ]);
+    const baseSidebar = [
+      { name: "Home", ptr: home_ptr },
+      { name: "Desktop", ptr: desktop_ptr },
+      { name: "Downloads", ptr: downloads_ptr },
+      { name: "Documents", ptr: documents_ptr },
+      { name: "Pictures", ptr: pictures_ptr },
+      { name: "Root", ptr: root_ptr }
+    ];
+
+    const sidebarDirs = computed(() => {
+      const dirs = [...baseSidebar];
+      if (remoteRootFolder.value) {
+        dirs.push({ name: remoteRootName.value, isManifest: true });
+      }
+      return dirs;
+    });
 
     return {
       contents,
@@ -150,6 +303,9 @@ setup() {
       back,
       forward,
       openFile,
+      handleFileDoubleClick,
+      handleSidebarClick,
+      isActiveSidebar,
       downloads_ptr,
       home_ptr,
       pictures_ptr,
@@ -159,7 +315,10 @@ setup() {
       directoryTitle,
       toRaw,
       sidebarDirs,
-      activePtr
+      activePtr,
+      hasManifest,
+      remoteRootFolder,
+      useManifest
     };
   },
 };

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -128,7 +128,7 @@ setup() {
       return node.type === 'd' ? node.entries ?? [] : [];
     });
 
-    const contents = computed(() => useManifest.value ? manifestContents.value : fsContents.value);
+    const contents = computed(() => (useManifest.value ? manifestContents.value : fsContents.value));
 
     // Navigation methods
     const chdir = (item) => {
@@ -268,6 +268,15 @@ setup() {
         activePtr.value = SystemModule.get_cur_fs_dir();
       }
       filesStore.loadManifest();
+    });
+
+    watch(remoteRootFolder, (folder) => {
+      if (folder && !useManifest.value) {
+        useManifest.value = true;
+        manifestHistory.value = [[]];
+        manifestHistoryIndex.value = 0;
+        updateManifestTitle();
+      }
     });
 
 

--- a/src/components/views/FileViewerView.vue
+++ b/src/components/views/FileViewerView.vue
@@ -42,6 +42,17 @@ export default {
       type: String, // File extension (e.g., 'txt', 'png', 'mp3')
       required: true,
     },
+    contentMode: {
+      type: String,
+      default: 'data', // 'data' = base64 data URI, 'url' = remote URL
+    },
+  },
+  data() {
+    return {
+      remoteTextContent: '',
+      remoteContentError: null,
+      remoteLoading: false,
+    };
   },
   computed: {
     isTextFile() {
@@ -60,8 +71,54 @@ export default {
       return this.file_ext.toLowerCase() == 'md';
     }
   },
+  watch: {
+    content: {
+      handler() {
+        this.prepareRemoteContent();
+      },
+      immediate: true,
+    },
+    contentMode() {
+      this.prepareRemoteContent();
+    },
+  },
   methods: {
+    async prepareRemoteContent() {
+      if (this.contentMode !== 'url' || !(this.isTextFile || this.isMarkdown)) {
+        this.remoteTextContent = '';
+        this.remoteContentError = null;
+        this.remoteLoading = false;
+        return;
+      }
+
+      this.remoteLoading = true;
+      this.remoteContentError = null;
+
+      try {
+        const response = await fetch(this.content, { cache: 'no-cache' });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        this.remoteTextContent = await response.text();
+      } catch (error) {
+        console.error('Unable to load remote content', error);
+        this.remoteContentError = error instanceof Error ? error.message : 'Unknown error';
+        this.remoteTextContent = '';
+      } finally {
+        this.remoteLoading = false;
+      }
+    },
     renderDecodedContent() {
+    if (this.contentMode === 'url') {
+      if (this.remoteContentError) {
+        return `Failed to load file: ${this.remoteContentError}`;
+      }
+      if (this.remoteLoading) {
+        return 'Loading remote file…';
+      }
+      return this.remoteTextContent.replace(/\n/g, "<br>");
+    }
+
     const decodedText = extractAndDecodeBase64(this.content);
     return decodedText.replace(/\n/g, "<br>");
     },
@@ -102,10 +159,19 @@ export default {
 
       // Decode Base64 content and parse Markdown
       try {
+        if (this.contentMode === 'url') {
+          if (this.remoteContentError) {
+            return `<p>Failed to load file: ${this.remoteContentError}</p>`;
+          }
+          if (this.remoteLoading) {
+            return '<p>Loading remote file…</p>';
+          }
+          return marked.parse(this.remoteTextContent, { renderer });
+        }
         const decodedContent = extractAndDecodeBase64(this.content);
         return marked.parse(decodedContent, { renderer });
       } catch (error) {
-        console.error("Error decoding Base64 content:", error);
+        console.error("Error decoding content:", error);
         return "<p>Invalid content provided.</p>";
       }
     }

--- a/src/components/windows/FileWindow.vue
+++ b/src/components/windows/FileWindow.vue
@@ -1,11 +1,12 @@
 <template>
   <BaseWindow v-bind="baseWindowProps" @export="downloadFile"
   :class="{'cursor-pointer': isMini}">
-    <FileViewerView 
+    <FileViewerView
       :content="item.content"
       :file_ext="item.exten"
       :name="item.name"
       :id="fileId"
+      :content-mode="item.contentMode ?? 'data'"
     />
   </BaseWindow>
 </template>
@@ -16,7 +17,7 @@ import FileViewerView from "@/components/views/FileViewerView.vue"
 import { useAppsStore } from "@/components/stores/apps"
 import { useExportFile } from '@/components/utilities/useExportFile'
 import { v4 as uuidv4 } from 'uuid';
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 const { exportFile } = useExportFile()
 
@@ -61,8 +62,18 @@ const downloadFile = async () => {
 };
 
 
+const minimizedIdentity = computed(() => {
+  if (props.item?.object?.$$?.ptr !== undefined) {
+    return `ptr-${props.item.object.$$.ptr}`;
+  }
+  if (props.item?.id) {
+    return `id-${props.item.id}`;
+  }
+  return `name-${props.item?.name ?? fileId}`;
+});
+
 const getMiniPos = () => {
-  const filebarWinContainer = document.getElementById(`filewin-${props.item.object.$$.ptr}`);
+  const filebarWinContainer = document.getElementById(`filewin-${minimizedIdentity.value}`);
 
   if (!filebarWinContainer) return { x: 0, y: 0 };
 


### PR DESCRIPTION
## Summary
- add a runtime files store and sample `portfolio-manifest.json` so desktop icons and the file manager can merge in remote content without rebuilding the WebAssembly filesystem
- teach the desktop, file manager, apps store, and windowing components to understand manifest-backed items (link handling, remote text fetching, stable file identities)
- document the manifest workflow and how to point the app at a Tina CMS/Git-based source for uploads

## Testing
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161d59ce98832f8417d92489d7ad78)