### PR TITLE
Ensure Sanity manifest file assets resolve URLs

### DIFF
--- a/src/components/stores/files.js
+++ b/src/components/stores/files.js
@@ -24,6 +24,7 @@ const sanityConfig = {
         href,
         assetUrl,
         "asset": asset->{url},
+        assetFileUrl: asset.asset->url,
         tags,
         meta
       },
@@ -140,7 +141,9 @@ const normalizeFileEntry = (entry = {}, parentSegments = []) => {
     entry.fileUrl,
     entry.href,
     entry.assetUrl,
+    entry.assetFileUrl,
     entry.asset?.url,
+    entry.asset?.asset?.url,
   );
   const resolvedContentMode =
     explicitMode ??


### PR DESCRIPTION
## Summary
- include the dereferenced Sanity file asset URL in the default manifest query
- allow the manifest normalizer to fall back to any asset-provided URL so asset-backed files have usable content

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691685cf8f90832f90fdddf4ff5fc6ce)