### PR TITLE
Support manifest root entries in CDN sync

### DIFF
--- a/public/portfolio-manifest.json
+++ b/public/portfolio-manifest.json
@@ -2,7 +2,21 @@
   "version": 1,
   "root": {
     "id": "remote-root",
-    "name": "Remote Files"
+    "name": "Remote Files",
+    "entries": [
+      {
+        "id": "remote-desktop",
+        "name": "Desktop",
+        "entries": [
+          {
+            "id": "desktop-note",
+            "name": "test",
+            "extension": "TXT",
+            "content": "Remote Desktop placeholder synced from the manifest."
+          }
+        ]
+      }
+    ]
   },
   "desktop": [
     {

--- a/shell_src_for_emcc/FileManagerContext.cpp
+++ b/shell_src_for_emcc/FileManagerContext.cpp
@@ -82,3 +82,21 @@ FileSystem::Directory* FileManagerContext::get_documents_dir_ptr() const {
 FileSystem::Directory* FileManagerContext::get_desktop_dir_ptr() const {
     return this->fs->get_desktop_dir_ptr();
 }
+
+FileSystem::Directory* FileManagerContext::create_directory(FileSystem::Directory* parent, const std::string& name) {
+    return this->fs->create_directory(parent, name);
+}
+
+FileSystem::Directory::File* FileManagerContext::create_file(
+    FileSystem::Directory* parent,
+    const std::string& name,
+    const std::string& extension_abbr,
+    const std::string& content,
+    bool is_shortcut,
+    bool is_link) {
+    return this->fs->create_file(parent, name, extension_abbr, content, is_shortcut, is_link);
+}
+
+void FileManagerContext::clear_directory(FileSystem::Directory* dir) {
+    this->fs->clear_directory(dir);
+}

--- a/shell_src_for_emcc/FileManagerContext.h
+++ b/shell_src_for_emcc/FileManagerContext.h
@@ -38,7 +38,17 @@ public:
     FileSystem::Directory* get_root_dir_ptr() const;
     FileSystem::Directory* get_documents_dir_ptr() const;
     FileSystem::Directory* get_desktop_dir_ptr() const;
-    
+
+    FileSystem::Directory* create_directory(FileSystem::Directory* parent, const std::string& name);
+    FileSystem::Directory::File* create_file(
+        FileSystem::Directory* parent,
+        const std::string& name,
+        const std::string& extension_abbr,
+        const std::string& content = "",
+        bool is_shortcut = false,
+        bool is_link = false);
+    void clear_directory(FileSystem::Directory* dir);
+
 private:
     FileSystem::Directory* cur_dir;
     std::vector<FileSystem::Directory*> back_history;

--- a/shell_src_for_emcc/SystemCore.cpp
+++ b/shell_src_for_emcc/SystemCore.cpp
@@ -63,3 +63,21 @@ FileSystem::Directory* SystemCore::get_documents_dir_ptr() const {
 FileSystem::Directory* SystemCore::get_desktop_dir_ptr() const {
     return this->f.get_desktop_dir_ptr();
 }
+
+FileSystem::Directory* SystemCore::create_directory(FileSystem::Directory* parent, const std::string& name) {
+    return this->f.create_directory(parent, name);
+}
+
+FileSystem::Directory::File* SystemCore::create_file(
+    FileSystem::Directory* parent,
+    const std::string& name,
+    const std::string& extension_abbr,
+    const std::string& content,
+    bool is_shortcut,
+    bool is_link) {
+    return this->f.create_file(parent, name, extension_abbr, content, is_shortcut, is_link);
+}
+
+void SystemCore::clear_directory(FileSystem::Directory* dir) {
+    this->f.clear_directory(dir);
+}

--- a/shell_src_for_emcc/SystemCore.h
+++ b/shell_src_for_emcc/SystemCore.h
@@ -31,6 +31,16 @@ public:
     FileSystem::Directory* get_desktop_dir_ptr() const;
 
     FileSystem::Directory* get_cur_fs_dir();
+
+    FileSystem::Directory* create_directory(FileSystem::Directory* parent, const std::string& name);
+    FileSystem::Directory::File* create_file(
+        FileSystem::Directory* parent,
+        const std::string& name,
+        const std::string& extension_abbr,
+        const std::string& content = "",
+        bool is_shortcut = false,
+        bool is_link = false);
+    void clear_directory(FileSystem::Directory* dir);
 };
 
 #endif // SYSTEMCORE_H

--- a/shell_src_for_emcc/encoders/to_base64.py
+++ b/shell_src_for_emcc/encoders/to_base64.py
@@ -51,5 +51,6 @@ def file_to_base64(directory):
         h_file.write("#endif /* FILES_H */")
 
 if __name__ == "__main__":
-    directory = "/Users/spicykneecaps/Projects/centari2013.github.io/shell_src_for_emcc/filesystem/files"  # Replace with your directory path
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    directory = os.path.join(repo_root, "filesystem", "files")
     file_to_base64(directory)

--- a/shell_src_for_emcc/filesystem/file_system.cpp
+++ b/shell_src_for_emcc/filesystem/file_system.cpp
@@ -279,9 +279,53 @@ std::vector<FileSystem::Directory::File*> FileSystem::list_files(FileSystem::Dir
     for (auto &f : dir->files){
         contents.push_back(f.get());
     }
-    
-    
+
+
     return contents;
+}
+
+void FileSystem::clear_directory(FileSystem::Directory* dir){
+    if (!dir){
+        return;
+    }
+    dir->files.clear();
+    dir->directories.clear();
+}
+
+FileSystem::Directory* FileSystem::create_directory(FileSystem::Directory* parent, const std::string& name){
+    if (!parent){
+        return nullptr;
+    }
+
+    auto it = std::find_if(parent->directories.begin(), parent->directories.end(), [&name](const std::unique_ptr<FileSystem::Directory>& dir){
+        return dir->name == name;
+    });
+
+    if (it != parent->directories.end()){
+        return it->get();
+    }
+
+    parent->directories.push_back(std::make_unique<FileSystem::Directory>(name, parent));
+    return parent->directories.back().get();
+}
+
+FileSystem::Directory::File* FileSystem::create_file(
+    FileSystem::Directory* parent,
+    const std::string& name,
+    const std::string& extension_abbr,
+    const std::string& content,
+    bool is_shortcut,
+    bool is_link){
+
+    if (!parent){
+        return nullptr;
+    }
+
+    auto file = std::make_shared<FileSystem::Directory::File>(name, extension_abbr, content);
+    file->is_shortcut = is_shortcut;
+    file->is_link = is_link;
+    parent->files.push_back(file);
+    return file.get();
 }
 
 std::vector<std::string> FileSystem::find(std::string f){

--- a/shell_src_for_emcc/filesystem/file_system.h
+++ b/shell_src_for_emcc/filesystem/file_system.h
@@ -186,16 +186,52 @@ public:
 
     /**
      * @brief Lists all current files in the current working directory.
-     * 
+     *
      * @param dir A valid pointer to a directory.
      * @return Returns a vector in alphabetic order.
      */
     std::vector<Directory::File*> list_files(Directory* dir);
-   
+
+
+    /**
+     * @brief Removes every file and sub-directory from the provided directory.
+     *
+     * @param dir Pointer to the directory that should be emptied.
+     */
+    void clear_directory(Directory* dir);
+
+    /**
+     * @brief Creates (or returns) a child directory beneath the provided parent.
+     *
+     * @param parent Pointer to the parent directory.
+     * @param name Name of the directory to create.
+     * @return Pointer to the created/existing directory.
+     */
+    Directory* create_directory(Directory* parent, const std::string& name);
+
+    /**
+     * @brief Creates a file entry inside the provided directory.
+     *
+     * @param parent Pointer to the directory that will own the file.
+     * @param name File name without extension delimiter.
+     * @param extension_abbr File extension/abbreviation.
+     * @param content Optional file payload/content.
+     * @param is_shortcut Indicates whether this file behaves like a shortcut.
+     * @param is_link Indicates whether this file should be treated as a browser link.
+     * @return Pointer to the created file instance.
+     */
+    Directory::File* create_file(
+        Directory* parent,
+        const std::string& name,
+        const std::string& extension_abbr,
+        const std::string& content = "",
+        bool is_shortcut = false,
+        bool is_link = false);
+
 
     /**
      * @brief NOT IMPLEMENTED
-     * 
+     *
      * @param f NOTIMPLEMENTED
      * @return NOT IMPLEMENTED
      */

--- a/shell_src_for_emcc/system.cpp
+++ b/shell_src_for_emcc/system.cpp
@@ -4,6 +4,7 @@
 
 #include <emscripten/bind.h>
 #include <emscripten.h>
+#include <string>
 
 
 
@@ -79,6 +80,24 @@ FileSystem::Directory::File* resolve_shortcut(FileSystem::Directory::File* f) {
     return (f && f->is_shortcut) ? f->shortcut_target.lock().get() : nullptr;
 }
 
+FileSystem::Directory* create_directory(FileSystem::Directory* parent, const std::string& name) {
+    return s.create_directory(parent, name);
+}
+
+FileSystem::Directory::File* create_file(
+    FileSystem::Directory* parent,
+    const std::string& name,
+    const std::string& extension_abbr,
+    const std::string& content,
+    bool is_shortcut,
+    bool is_link) {
+    return s.create_file(parent, name, extension_abbr, content, is_shortcut, is_link);
+}
+
+void clear_directory(FileSystem::Directory* dir) {
+    s.clear_directory(dir);
+}
+
 
 // Expose the functions to JavaScript
 EMSCRIPTEN_BINDINGS(terminal) {
@@ -123,5 +142,9 @@ EMSCRIPTEN_BINDINGS(file_manager) {
     emscripten::function("get_desktop_dir_ptr", &get_desktop_dir_ptr, emscripten::allow_raw_pointers());
 
     emscripten::function("resolve_shortcut", &resolve_shortcut, emscripten::allow_raw_pointers());
-    
+
+    emscripten::function("create_directory", &create_directory, emscripten::allow_raw_pointers());
+    emscripten::function("create_file", &create_file, emscripten::allow_raw_pointers());
+    emscripten::function("clear_directory", &clear_directory, emscripten::allow_raw_pointers());
+
 }

--- a/src/components/desktop/Desktop.vue
+++ b/src/components/desktop/Desktop.vue
@@ -47,6 +47,7 @@ import Taskbar from '@/components/desktop/Taskbar.vue';
 import MinimizedFileBar from '@/components/desktop/MinimizedFileBar.vue';
 
 import { createLoader } from '@/components/utilities/simulateLoading';
+import { onSystemModuleReady } from '@/components/utilities/systemModuleReady';
 
 import { ref, toRaw, defineAsyncComponent, reactive, provide, onMounted, computed } from 'vue';
 
@@ -136,13 +137,12 @@ const handleFileOpen = (item) => {
 }
 
 onMounted(() => {
-  // initialize file system
-  SystemModule.onRuntimeInitialized = () => {
+  onSystemModuleReady(() => {
     loader.checkpoint()
     console.log("SystemModule is fully initialized.");
     systemDesktopContents.value = getDesktopContents();
     loader.checkpoint()
-  };
+  });
 
   loader.done.then(() => emit('initialized'))
 

--- a/src/components/stores/files.js
+++ b/src/components/stores/files.js
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia';
+import { syncManifestToFs } from '@/components/utilities/syncManifestToFs';
 
 const defaultManifestUrl = import.meta.env.VITE_MANIFEST_URL ?? '/portfolio-manifest.json';
 
@@ -164,13 +165,25 @@ const normalizeFileEntry = (entry = {}, parentSegments = []) => {
   };
 };
 
+const shouldNormalizeAsFolder = (entry) => {
+  if (!entry) {
+    return false;
+  }
+  if (Array.isArray(entry.entries)) {
+    return true;
+  }
+  const kind = typeof entry.kind === 'string' ? entry.kind.toLowerCase() : null;
+  const type = typeof entry.type === 'string' ? entry.type.toLowerCase() : null;
+  return kind === 'folder' || type === 'd';
+};
+
 const normalizeFolder = (folder = {}, parentSegments = []) => {
   const folderName = folder.name ?? 'Folder';
   const id = folder.id ?? slugify([...parentSegments, folderName].join('-')) ?? randomId();
   const nextSegments = [...parentSegments, folderName];
   const entries = Array.isArray(folder.entries)
     ? folder.entries.map((entry) =>
-        entry.entries || entry.kind === 'folder'
+        shouldNormalizeAsFolder(entry)
           ? normalizeFolder(entry, nextSegments)
           : normalizeFileEntry(entry, nextSegments),
       )
@@ -187,12 +200,20 @@ const normalizeFolder = (folder = {}, parentSegments = []) => {
 
 const normalizeManifest = (payload = {}) => {
   const rootConfig = payload.root ?? {};
+  const remoteSegments = [rootConfig.name ?? 'remote'];
+  const rootEntries = Array.isArray(rootConfig.entries)
+    ? rootConfig.entries.map((entry) =>
+        shouldNormalizeAsFolder(entry)
+          ? normalizeFolder(entry, remoteSegments)
+          : normalizeFileEntry(entry, remoteSegments),
+      )
+    : [];
   const desktopEntries = Array.isArray(payload.desktop)
     ? payload.desktop.map((entry) => normalizeFileEntry(entry, ['desktop']))
     : [];
 
   const remoteFolders = Array.isArray(payload.folders)
-    ? payload.folders.map((folder) => normalizeFolder(folder, [rootConfig.name ?? 'remote']))
+    ? payload.folders.map((folder) => normalizeFolder(folder, remoteSegments))
     : [];
 
   return {
@@ -202,7 +223,7 @@ const normalizeManifest = (payload = {}) => {
       name: rootConfig.name ?? 'Remote Files',
       type: 'd',
       source: 'manifest',
-      entries: remoteFolders,
+      entries: [...rootEntries, ...remoteFolders],
     },
   };
 };
@@ -243,6 +264,7 @@ export const useFilesStore = defineStore('files', {
 
         this.manifestUrl = sourceKey;
         this.manifest = normalizeManifest(payload);
+        await syncManifestToFs(this.manifest);
         this.status = 'ready';
       } catch (error) {
         console.error('[filesStore] Failed to load manifest', error);

--- a/src/components/utilities/syncManifestToFs.js
+++ b/src/components/utilities/syncManifestToFs.js
@@ -1,0 +1,66 @@
+import { whenSystemModuleReady } from './systemModuleReady';
+
+const sanitizeExtension = (value = '') => value.replace(/^\./, '').trim();
+
+const ensureFsSupport = (module) =>
+  typeof module?.clear_directory === 'function' &&
+  typeof module?.create_directory === 'function' &&
+  typeof module?.create_file === 'function';
+
+const createFsEntry = (module, parentPtr, entry) => {
+  if (!parentPtr || !entry) {
+    return;
+  }
+
+  if (entry.type === 'd') {
+    const dirPtr = module.create_directory(parentPtr, entry.name ?? 'Folder');
+    if (!dirPtr) {
+      return;
+    }
+    module.clear_directory(dirPtr);
+    (entry.entries ?? []).forEach((child) => {
+      createFsEntry(module, dirPtr, child);
+    });
+    return;
+  }
+
+  const extension = sanitizeExtension(entry.exten ?? entry.extension ?? '');
+  const isLink = entry.is_link || entry.contentMode === 'url';
+  module.create_file(parentPtr, entry.name ?? 'File', extension, entry.content ?? '', Boolean(entry.is_shortcut), isLink);
+};
+
+export const syncManifestToFs = async (manifest) => {
+  if (!manifest) {
+    return;
+  }
+
+  const module = await whenSystemModuleReady();
+  if (!ensureFsSupport(module)) {
+    console.warn('[syncManifestToFs] SystemModule does not expose filesystem mutators.');
+    return;
+  }
+
+  const desktopDir = module.get_desktop_dir_ptr?.();
+  if (desktopDir) {
+    module.clear_directory(desktopDir);
+    (manifest.desktop ?? []).forEach((entry) => createFsEntry(module, desktopDir, entry));
+  }
+
+  const remoteRootConfig = manifest.remoteRoot;
+  if (!remoteRootConfig) {
+    return;
+  }
+
+  const homeDir = module.get_home_dir_ptr?.();
+  if (!homeDir) {
+    return;
+  }
+
+  const remoteRootDir = module.create_directory(homeDir, remoteRootConfig.name ?? 'Remote Files');
+  if (!remoteRootDir) {
+    return;
+  }
+
+  module.clear_directory(remoteRootDir);
+  (remoteRootConfig.entries ?? []).forEach((entry) => createFsEntry(module, remoteRootDir, entry));
+};

--- a/src/components/utilities/systemModuleReady.js
+++ b/src/components/utilities/systemModuleReady.js
@@ -1,0 +1,80 @@
+const readyCallbacks = [];
+let readyPromiseResolve;
+let readyPromise;
+let isReady = false;
+let isHookInstalled = false;
+const schedule = typeof requestAnimationFrame === 'function' ? requestAnimationFrame : (cb) => setTimeout(cb, 16);
+
+const getOrCreatePromise = () => {
+  if (!readyPromise) {
+    readyPromise = new Promise((resolve) => {
+      readyPromiseResolve = resolve;
+    });
+  }
+  return readyPromise;
+};
+
+const markReady = () => {
+  if (isReady) {
+    return;
+  }
+  if (typeof SystemModule === 'undefined') {
+    return;
+  }
+  isReady = true;
+  const resolve = readyPromiseResolve;
+  if (resolve) {
+    resolve(SystemModule);
+  }
+  readyCallbacks.splice(0).forEach((cb) => {
+    try {
+      cb(SystemModule);
+    } catch (error) {
+      console.error('[systemModuleReady] callback failed', error);
+    }
+  });
+};
+
+const installHook = () => {
+  if (isHookInstalled || typeof window === 'undefined') {
+    return;
+  }
+  isHookInstalled = true;
+
+  const waitForModule = () => {
+    if (typeof SystemModule === 'undefined') {
+      schedule(waitForModule);
+      return;
+    }
+
+    if (SystemModule.calledRun) {
+      markReady();
+      return;
+    }
+
+    const previousHandler = SystemModule.onRuntimeInitialized;
+    SystemModule.onRuntimeInitialized = () => {
+      previousHandler?.();
+      markReady();
+    };
+  };
+
+  waitForModule();
+};
+
+export const whenSystemModuleReady = async () => {
+  installHook();
+  if (typeof SystemModule !== 'undefined' && SystemModule.calledRun) {
+    markReady();
+  }
+  return getOrCreatePromise();
+};
+
+export const onSystemModuleReady = (callback) => {
+  installHook();
+  if (isReady && typeof SystemModule !== 'undefined') {
+    callback(SystemModule);
+    return;
+  }
+  readyCallbacks.push(callback);
+};


### PR DESCRIPTION
## Summary
- allow manifest folder normalization to treat both `root.entries` and `folders` payloads as part of the remote tree so nested directories or loose files defined under `root` are materialized in the native filesystem
- update the sample manifest to include an example desktop folder and note defined directly inside the `root` block so the behavior is immediately verifiable in the terminal/file manager views

## Testing
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69169b0990b8832f92407d82a863ab32)