### PR TITLE
Sync Sanity manifest across UI and terminal

### DIFF
--- a/src/components/desktop/Desktop.vue
+++ b/src/components/desktop/Desktop.vue
@@ -49,7 +49,7 @@ import MinimizedFileBar from '@/components/desktop/MinimizedFileBar.vue';
 import { createLoader } from '@/components/utilities/simulateLoading';
 import { onSystemModuleReady } from '@/components/utilities/systemModuleReady';
 
-import { ref, toRaw, defineAsyncComponent, reactive, provide, onMounted, computed } from 'vue';
+import { ref, toRaw, defineAsyncComponent, reactive, provide, onMounted, computed, watch } from 'vue';
 
 const ContentWindow = defineAsyncComponent(() => import("@/components/windows/ContentWindow.vue"));
 const emit = defineEmits(['initialized', 'progress'])
@@ -73,15 +73,9 @@ const fmId = 'file_manager'
 const browserId = 'browser'
 
 const filesStore = useFilesStore();
-const { desktopManifestItems } = storeToRefs(filesStore);
+const { fsSyncVersion } = storeToRefs(filesStore);
 
-const desktopContents = computed(() => {
-  const manifestItems = desktopManifestItems.value ?? [];
-  if (manifestItems.length) {
-    return manifestItems;
-  }
-  return systemDesktopContents.value ?? [];
-});
+const desktopContents = computed(() => systemDesktopContents.value ?? []);
 
 const loader = createLoader(2, p => emit('progress', p))
 
@@ -114,6 +108,13 @@ const getDesktopContents = () => {
   return contentsList;
 };
 
+const refreshDesktopContents = () => {
+  if (typeof SystemModule === 'undefined' || !SystemModule.get_desktop_dir_ptr) {
+    return;
+  }
+  systemDesktopContents.value = getDesktopContents();
+};
+
 const randomPositions = new Map();
 
 const getRandomPosition = (id) => {
@@ -140,13 +141,17 @@ onMounted(() => {
   onSystemModuleReady(() => {
     loader.checkpoint()
     console.log("SystemModule is fully initialized.");
-    systemDesktopContents.value = getDesktopContents();
+    refreshDesktopContents();
     loader.checkpoint()
   });
 
   loader.done.then(() => emit('initialized'))
 
 })
+
+watch(fsSyncVersion, () => {
+  refreshDesktopContents();
+});
 
 onMounted(() => {
   filesStore.loadManifest();

--- a/src/components/stores/files.js
+++ b/src/components/stores/files.js
@@ -234,6 +234,7 @@ export const useFilesStore = defineStore('files', {
     error: null,
     manifest: null,
     manifestUrl: defaultManifestUrl,
+    fsSyncVersion: 0,
   }),
   getters: {
     desktopManifestItems: (state) => state.manifest?.desktop ?? [],
@@ -265,6 +266,7 @@ export const useFilesStore = defineStore('files', {
         this.manifestUrl = sourceKey;
         this.manifest = normalizeManifest(payload);
         await syncManifestToFs(this.manifest);
+        this.fsSyncVersion += 1;
         this.status = 'ready';
       } catch (error) {
         console.error('[filesStore] Failed to load manifest', error);

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -82,7 +82,7 @@ setup() {
     const manifestHistory = ref([[]]);
     const manifestHistoryIndex = ref(0);
     const filesStore = useFilesStore();
-    const { remoteRootFolder, hasManifest, remoteRootName } = storeToRefs(filesStore);
+    const { remoteRootFolder, hasManifest, remoteRootName, fsSyncVersion } = storeToRefs(filesStore);
     const appsStore = useAppsStore();
     const browserId = 'browser';
 
@@ -130,6 +130,13 @@ setup() {
 
     const contents = computed(() => (useManifest.value ? manifestContents.value : fsContents.value));
 
+    const refreshFsContents = () => {
+      if (useManifest.value) {
+        return;
+      }
+      fsContents.value = getDirContents();
+    };
+
     // Navigation methods
     const chdir = (item) => {
       if (typeof SystemModule === 'undefined' || !SystemModule.cd) {
@@ -138,7 +145,7 @@ setup() {
       useManifest.value = false;
       SystemModule.cd(item);
       activePtr.value = item; // <-- track current ptr
-      fsContents.value = getDirContents();
+      refreshFsContents();
     };
 
     const enterManifestDirectory = (dirId) => {
@@ -159,7 +166,7 @@ setup() {
         return;
       }
       SystemModule.cd_back();
-      fsContents.value = getDirContents();
+      refreshFsContents();
     };
 
     const forward = () => {
@@ -173,7 +180,7 @@ setup() {
         return;
       }
       SystemModule.cd_forward();
-      fsContents.value = getDirContents();
+      refreshFsContents();
     };
 
     const disableBack = computed(() => {
@@ -277,6 +284,10 @@ setup() {
         manifestHistoryIndex.value = 0;
         updateManifestTitle();
       }
+    });
+
+    watch(fsSyncVersion, () => {
+      refreshFsContents();
     });
 
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,12 +4,17 @@ import '../node_modules/augmented-ui/augmented-ui.min.css'
 import './style.css'
 import '@/assets/js/terminal/system';
 import App from '@/App.vue';
+import { useFilesStore } from '@/components/stores/files';
 
 
 const app = createApp(App);
 const pinia = createPinia();
 
 app.use(pinia); // Register Pinia
+
+const filesStore = useFilesStore(pinia);
+filesStore.loadManifest();
+
 app.mount('#app'); // Mount the app
 
 


### PR DESCRIPTION
## Summary
- load the portfolio manifest through the files store during app bootstrap and track each filesystem sync
- refresh the desktop and file manager views from the C++ filesystem whenever the manifest resyncs so the UI and terminal see the same files

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916aa1ee630832f9e2099f3bd08d26c)