### PR TITLE
Add offline fallback manifest

### DIFF
--- a/src/components/data/fallbackManifest.js
+++ b/src/components/data/fallbackManifest.js
@@ -1,0 +1,274 @@
+const repoAsset = (name) =>
+  `https://raw.githubusercontent.com/Centari2013/centari2013.github.io/main/shell_src_for_emcc/filesystem/files/${name}`;
+
+const desktopReadme = `# Welcome to SpicyOS
+
+This is the offline manifest that ships with the repo so you can explore the fake filesystem without wiring up
+Sanity. Once your remote CMS is configured this tree will be replaced automatically, but the commands still work
+exactly the same.
+`;
+
+const resumeMd = `# Résumé (Offline Extract)
+
+## Core Focus
+- Systems programming, WebAssembly, weird UI experiments.
+- Ship fast, leave the neon LEDs on.
+
+## Recent Work
+- Built SpicyOS, a fake operating system portfolio.
+- Ported a POSIX-inspired shell from C++ to WebAssembly.
+`;
+
+const aboutMeMd = `# About Me
+
+Hi, I'm Zaria (aka SpicyKneecaps). When I'm not writing C++ for fun, I'm usually making the browser pretend it's a
+terminal. This fallback tree exists so the \`tree\`, \`ls\`, and \`type\` commands always have something interesting to
+show you.
+`;
+
+const logTxt = `== install.log ==
+[BOOT] Provisioning SpicyOS offline manifest.
+[OK] Linked desktop shortcuts.
+[OK] Mounted documents and dotfiles.
+`;
+
+const cacheTxt = `Directory: /var/cache
+The cache stores precomputed data so repeated operations stay fast. Clearing it will free some space, but the system
+will regenerate whatever it needs on demand.
+`;
+
+const tmpTxt = `Directory: /tmp
+Temporary scratch space for downloads, shell experiments, and code snippets. Everything here is ephemeral so don't
+get too attached.
+`;
+
+const hostnameTxt = 'spicyos-offline\n';
+
+const passwdTxt = `root:x:0:0:root:/root:/bin/bash
+zaria:x:1001:1001:Zaria SpicyKneecaps:/home/SpicyKneecaps:/bin/bash
+`;
+
+const shadowTxt = `root:*:19876:0:99999:7:::
+zaria:*:19876:0:99999:7:::
+`;
+
+const gccTxt = `gcc (Spicy toolchain) 13.2.0
+Copyright (C) 2024 Zaria SpicyKneecaps
+This is a fake binary that prints help text so \`type /usr/bin/gcc\` has something to display offline.
+`;
+
+const pythonTxt = `Python 3.12.1 (fake build)
+>>> print('Hello from the fallback manifest!')
+Hello from the fallback manifest!
+`;
+
+const lsTxt = `Usage: ls [directory]
+Lists the contents of the target directory. Supports the faux filesystem that backs SpicyOS.
+`;
+
+const echoTxt = `Usage: echo [text]
+Exactly what you'd expect.
+`;
+
+const fallbackManifest = {
+  version: 1,
+  root: { name: 'SpicyOS Filesystem' },
+  desktop: [
+    {
+      id: 'desktop-readme',
+      name: 'README.md',
+      extension: 'MD',
+      contentMode: 'data',
+      content: desktopReadme,
+      kind: 'file',
+    },
+    {
+      id: 'desktop-sound-room',
+      name: 'SoundRoom.link',
+      extension: 'LINK',
+      kind: 'link',
+      contentMode: 'url',
+      content: 'https://centari2013.github.io/SoundRoom/',
+    },
+  ],
+  filesystem: [
+    {
+      id: 'root-bin',
+      name: 'bin',
+      role: 'bin',
+      entries: [
+        { id: 'bin-ls', name: 'ls', contentMode: 'data', content: lsTxt },
+        { id: 'bin-echo', name: 'echo', contentMode: 'data', content: echoTxt },
+      ],
+    },
+    {
+      id: 'root-etc',
+      name: 'etc',
+      role: 'etc',
+      entries: [
+        { id: 'etc-hostname', name: 'hostname.txt', extension: 'TXT', contentMode: 'data', content: hostnameTxt },
+        { id: 'etc-passwd', name: 'passwd.txt', extension: 'TXT', contentMode: 'data', content: passwdTxt },
+        { id: 'etc-shadow', name: 'shadow.txt', extension: 'TXT', contentMode: 'data', content: shadowTxt },
+      ],
+    },
+    {
+      id: 'root-home',
+      name: 'home',
+      role: 'home',
+      entries: [
+        {
+          id: 'home-zaria',
+          name: 'SpicyKneecaps',
+          role: 'users',
+          entries: [
+            {
+              id: 'home-desktop',
+              name: 'Desktop',
+              role: 'desktop',
+              entries: [
+                {
+                  id: 'desktop-readme-copy',
+                  name: 'README.md',
+                  extension: 'MD',
+                  contentMode: 'data',
+                  content: desktopReadme,
+                },
+                {
+                  id: 'desktop-sound-room-shortcut',
+                  name: 'Sound Room.url',
+                  extension: 'URL',
+                  kind: 'link',
+                  contentMode: 'url',
+                  content: 'https://centari2013.github.io/SoundRoom/',
+                },
+              ],
+            },
+            {
+              id: 'home-documents',
+              name: 'Documents',
+              role: 'documents',
+              entries: [
+                { id: 'documents-resume', name: 'Resume.md', extension: 'MD', contentMode: 'data', content: resumeMd },
+                { id: 'documents-about', name: 'AboutMe.md', extension: 'MD', contentMode: 'data', content: aboutMeMd },
+              ],
+            },
+            {
+              id: 'home-downloads',
+              name: 'Downloads',
+              role: 'downloads',
+              entries: [
+                { id: 'downloads-log', name: 'install.log', extension: 'LOG', contentMode: 'data', content: logTxt },
+                { id: 'downloads-cache-note', name: 'cache.txt', extension: 'TXT', contentMode: 'data', content: cacheTxt },
+              ],
+            },
+            {
+              id: 'home-pictures',
+              name: 'Pictures',
+              role: 'pictures',
+              entries: [
+                {
+                  id: 'pictures-hiiii',
+                  name: 'hiiii.jpeg',
+                  extension: 'JPEG',
+                  contentMode: 'url',
+                  content: repoAsset('hiiii.jpeg'),
+                },
+                {
+                  id: 'pictures-itsa-me',
+                  name: 'its_a_me.jpeg',
+                  extension: 'JPEG',
+                  contentMode: 'url',
+                  content: repoAsset('its_a_me.jpeg'),
+                },
+                {
+                  id: 'pictures-mel',
+                  name: 'mel_cosplay_makeup.jpeg',
+                  extension: 'JPEG',
+                  contentMode: 'url',
+                  content: repoAsset('mel_cosplay_makeup.jpeg'),
+                },
+              ],
+            },
+            {
+              id: 'home-projects',
+              name: 'Projects',
+              entries: [
+                {
+                  id: 'projects-shell',
+                  name: 'shell',
+                  entries: [
+                    {
+                      id: 'projects-shell-files-cpp',
+                      name: 'files.cpp',
+                      extension: 'CPP',
+                      contentMode: 'url',
+                      content: repoAsset('files.cpp'),
+                    },
+                    {
+                      id: 'projects-shell-files-h',
+                      name: 'files.h',
+                      extension: 'H',
+                      contentMode: 'url',
+                      content: repoAsset('files.h'),
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'root-tmp',
+      name: 'tmp',
+      role: 'tmp',
+      entries: [{ id: 'tmp-readme', name: 'README.txt', extension: 'TXT', contentMode: 'data', content: tmpTxt }],
+    },
+    {
+      id: 'root-usr',
+      name: 'usr',
+      role: 'usr',
+      entries: [
+        {
+          id: 'usr-bin',
+          name: 'bin',
+          role: 'usr/bin',
+          entries: [
+            { id: 'usr-bin-gcc', name: 'gcc', contentMode: 'data', content: gccTxt },
+            { id: 'usr-bin-python', name: 'python3', contentMode: 'data', content: pythonTxt },
+          ],
+        },
+        {
+          id: 'usr-sbin',
+          name: 'sbin',
+          role: 'usr/sbin',
+          entries: [],
+        },
+      ],
+    },
+    {
+      id: 'root-var',
+      name: 'var',
+      role: 'var',
+      entries: [
+        {
+          id: 'var-log',
+          name: 'log',
+          entries: [
+            { id: 'var-log-system', name: 'system.log', extension: 'LOG', contentMode: 'data', content: logTxt },
+          ],
+        },
+        {
+          id: 'var-cache',
+          name: 'cache',
+          entries: [
+            { id: 'var-cache-readme', name: 'README.txt', extension: 'TXT', contentMode: 'data', content: cacheTxt },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export default fallbackManifest;

--- a/src/components/stores/files.js
+++ b/src/components/stores/files.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { syncManifestToFs } from '@/components/utilities/syncManifestToFs';
+import fallbackManifest from '@/components/data/fallbackManifest';
 
 const sanityConfig = {
   projectId: import.meta.env.VITE_SANITY_PROJECT_ID,
@@ -42,15 +43,6 @@ const sanityConfig = {
 
 const hasSanityConfig = Boolean(sanityConfig.projectId && sanityConfig.dataset);
 
-const requireSanityConfig = () => {
-  if (hasSanityConfig) {
-    return;
-  }
-  throw new Error(
-    'Sanity credentials are missing. Set VITE_SANITY_PROJECT_ID and VITE_SANITY_DATASET to load the manifest.',
-  );
-};
-
 const parseSanityParams = () => {
   if (!sanityConfig.params) {
     return null;
@@ -92,6 +84,33 @@ const fetchSanityManifest = async () => {
   }
 
   return payload.result;
+};
+
+const cloneManifestPayload = (payload = {}) => JSON.parse(JSON.stringify(payload));
+
+const buildFallbackManifest = (reason) => {
+  if (!fallbackManifest) {
+    throw new Error(reason);
+  }
+  console.warn(`[filesStore] ${reason} Falling back to bundled manifest.`);
+  return cloneManifestPayload(fallbackManifest);
+};
+
+const loadManifestPayload = async () => {
+  if (!hasSanityConfig) {
+    return buildFallbackManifest('Sanity credentials missing.');
+  }
+
+  try {
+    const remoteManifest = await fetchSanityManifest();
+    if (!remoteManifest || Object.keys(remoteManifest).length === 0) {
+      return buildFallbackManifest('Sanity returned an empty manifest.');
+    }
+    return remoteManifest;
+  } catch (error) {
+    console.error('[filesStore] Failed to load manifest from Sanity', error);
+    return buildFallbackManifest('Sanity fetch failed.');
+  }
 };
 
 const randomId = () => {
@@ -273,8 +292,6 @@ export const useFilesStore = defineStore('files', {
   },
   actions: {
     async loadManifest() {
-      requireSanityConfig();
-
       if (this.status === 'loading') {
         return;
       }
@@ -287,7 +304,7 @@ export const useFilesStore = defineStore('files', {
       this.error = null;
 
       try {
-        const payload = await fetchSanityManifest();
+        const payload = await loadManifestPayload();
         this.manifest = normalizeManifest(payload);
         const syncResult = await syncManifestToFs(this.manifest);
         this.remoteRootDir = syncResult?.remoteRootDir ?? null;


### PR DESCRIPTION
## Summary
- add a bundled filesystem manifest that mirrors the basic SpicyOS tree so the shell has content even without Sanity
- update the files store to clone the Sanity payload when available or fall back to the bundled manifest if credentials are missing or the query fails

## Testing
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917f5f86fc0832fb3238bfcc5e75824)