### PR TITLE
Improve Sanity manifest diagnostics and role docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,24 @@ Without `VITE_SANITY_PROJECT_ID` **and** `VITE_SANITY_DATASET` the app refuses t
 - Set `kind: "link"` (or `launch: "browser"`) to open a URL in the in-app browser.
 - Use `contentMode: "url"` whenever the `content` points at an external file; otherwise the viewer assumes a Base64 data URI.
 
+### System roles that matter
+
+The manifest normalizer in [`src/components/stores/files.js`](src/components/stores/files.js) inspects a `role` (or `systemRole`) property on folders to decide where they mount inside the faux Unix tree. Assign roles whenever the folder is meant to behave like an OS directory—otherwise it is treated as a generic folder.
+
+The runtime currently recognizes the following roles:
+
+```
+bin, custom, desktop, documents, downloads, etc,
+home, pictures, sbin, tmp, usr, usr/bin, usr/sbin,
+users, var
+```
+
+- `home` + `desktop` ensure the desktop icons and the shell point at the same path. When no `desktop` role is found the store fabricates a `home/SpicyOS/Desktop` tree, but explicitly tagging your folders avoids surprises.
+- `bin`, `usr/bin`, and `usr/sbin` are merged into the WASM shell's `$PATH`. If you leave them untagged, the CLI won't see the manifest-provided executables.
+- `documents`, `downloads`, `pictures`, etc. signal to the UI which folders deserve bespoke icons/labels.
+
+Any folder without one of the roles above still loads—it just behaves like a plain directory.
+
 Because the SPA fetches the manifest straight from Sanity on every page load, any publish in Studio (or via mutations/scripts) immediately refreshes the filesystem—no JSON files, repos, or WebAssembly rebuilds are required.
 
 #### Example schema

--- a/src/components/stores/files.js
+++ b/src/components/stores/files.js
@@ -43,6 +43,14 @@ const sanityConfig = {
 
 const hasSanityConfig = Boolean(sanityConfig.projectId && sanityConfig.dataset);
 
+const logSanityFailure = (message, details) => {
+  if (details) {
+    console.error(`[filesStore] ${message}`, details);
+    return;
+  }
+  console.error(`[filesStore] ${message}`);
+};
+
 const parseSanityParams = () => {
   if (!sanityConfig.params) {
     return null;
@@ -62,20 +70,46 @@ const fetchSanityManifest = async () => {
   const encodedParams = params ? `&${new URLSearchParams(Object.entries(params)).toString()}` : '';
   const endpoint = `https://${projectId}.api.sanity.io/${apiVersion}/data/query/${dataset}?query=${encodedQuery}${encodedParams}`;
 
-  const response = await fetch(endpoint, {
-    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-  });
+  let response;
+  try {
+    response = await fetch(endpoint, {
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    });
+  } catch (error) {
+    logSanityFailure('Network error while fetching manifest from Sanity.', { endpoint, error });
+    throw error;
+  }
 
   if (!response.ok) {
+    let body = null;
+    try {
+      body = await response.text();
+    } catch (readError) {
+      body = '<unavailable>';
+    }
+    logSanityFailure('Sanity query failed.', {
+      endpoint,
+      status: response.status,
+      statusText: response.statusText,
+      body,
+    });
     throw new Error(`Sanity query failed (HTTP ${response.status})`);
   }
 
-  const payload = await response.json();
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    logSanityFailure('Unable to parse Sanity response JSON.', error);
+    throw error;
+  }
   if (payload.error) {
+    logSanityFailure('Sanity response returned an error.', payload.error);
     throw new Error(payload.error.description ?? 'Sanity query returned an error');
   }
 
   if (!payload.result) {
+    logSanityFailure('Sanity response was missing a result.', payload);
     throw new Error('Sanity response did not include a result');
   }
 
@@ -98,12 +132,14 @@ const buildFallbackManifest = (reason) => {
 
 const loadManifestPayload = async () => {
   if (!hasSanityConfig) {
+    console.warn('[filesStore] Missing Sanity credentials. Falling back to bundled manifest.');
     return buildFallbackManifest('Sanity credentials missing.');
   }
 
   try {
     const remoteManifest = await fetchSanityManifest();
     if (!remoteManifest || Object.keys(remoteManifest).length === 0) {
+      logSanityFailure('Sanity returned an empty manifest.', remoteManifest);
       return buildFallbackManifest('Sanity returned an empty manifest.');
     }
     return remoteManifest;


### PR DESCRIPTION
## Summary
- add detailed console logging and helper utilities so every Sanity failure is surfaced in the console before falling back to the bundled manifest
- document the filesystem roles the runtime recognizes so manifest authors know which folders need explicit tags

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195c35fb38832faa891e00289de54c)