### PR TITLE
Fix manifest cloning when entries are Vue proxies

### DIFF
--- a/src/components/utilities/syncManifestToFs.js
+++ b/src/components/utilities/syncManifestToFs.js
@@ -1,4 +1,33 @@
+import { isProxy, toRaw } from 'vue';
 import { whenSystemModuleReady } from './systemModuleReady';
+
+const unwrapProxies = (value, seen = new WeakMap()) => {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const source = isProxy(value) ? toRaw(value) : value;
+
+  if (seen.has(source)) {
+    return seen.get(source);
+  }
+
+  if (Array.isArray(source)) {
+    const result = [];
+    seen.set(source, result);
+    for (const entry of source) {
+      result.push(unwrapProxies(entry, seen));
+    }
+    return result;
+  }
+
+  const result = {};
+  seen.set(source, result);
+  for (const [key, entry] of Object.entries(source)) {
+    result[key] = unwrapProxies(entry, seen);
+  }
+  return result;
+};
 
 const ensureFsSupport = (module) => typeof module?.build_fs_from_manifest === 'function';
 
@@ -7,16 +36,18 @@ const cloneManifestEntries = (entries) => {
     return null;
   }
 
+  const plainEntries = unwrapProxies(entries);
+
   if (typeof globalThis.structuredClone === 'function') {
     try {
-      return globalThis.structuredClone(entries);
+      return globalThis.structuredClone(plainEntries);
     } catch (error) {
       console.warn('[syncManifestToFs] structuredClone failed, falling back to JSON copy.', error);
     }
   }
 
   try {
-    return JSON.parse(JSON.stringify(entries));
+    return JSON.parse(JSON.stringify(plainEntries));
   } catch (error) {
     console.error('[syncManifestToFs] Unable to serialize manifest entries for SystemModule.', error);
     return null;


### PR DESCRIPTION
## Summary
- unwrap Vue proxy objects in the filesystem manifest before attempting to clone it so the wasm module receives plain data
- keep the structuredClone/JSON fallback logic but feed it the sanitized payload so hydration no longer throws DOMException warnings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691966bf8ac0832fbcd55d2bd39f1094)