### PR TITLE
Fix manifest cloning regression

### DIFF
--- a/src/components/utilities/syncManifestToFs.js
+++ b/src/components/utilities/syncManifestToFs.js
@@ -1,3 +1,4 @@
+import { toRaw } from 'vue';
 import { whenSystemModuleReady } from './systemModuleReady';
 
 const ensureFsSupport = (module) => typeof module?.build_fs_from_manifest === 'function';
@@ -7,16 +8,9 @@ const cloneManifestEntries = (entries) => {
     return null;
   }
 
-  if (typeof globalThis.structuredClone === 'function') {
-    try {
-      return globalThis.structuredClone(entries);
-    } catch (error) {
-      console.warn('[syncManifestToFs] structuredClone failed, falling back to JSON copy.', error);
-    }
-  }
-
   try {
-    return JSON.parse(JSON.stringify(entries));
+    const rawEntries = toRaw(entries);
+    return JSON.parse(JSON.stringify(rawEntries));
   } catch (error) {
     console.error('[syncManifestToFs] Unable to serialize manifest entries for SystemModule.', error);
     return null;


### PR DESCRIPTION
## Summary
- remove the recursive proxy unwrapping logic that corrupted manifest payloads before handing them to the wasm module
- always clone the manifest entries via `JSON.parse(JSON.stringify(toRaw(entries)))` so Vue proxies are stripped without disturbing the manifest schema

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691966bf8ac0832fbcd55d2bd39f1094)