### PR TITLE
feat: add dynamic file rendering pipeline

### DIFF
--- a/src/components/utilities/fileLoader.js
+++ b/src/components/utilities/fileLoader.js
@@ -1,0 +1,202 @@
+const EXTENSION_MIME_MAP = {
+  txt: 'text/plain',
+  md: 'text/markdown',
+  markdown: 'text/markdown',
+  json: 'application/json',
+  js: 'application/javascript',
+  ts: 'application/typescript',
+  css: 'text/css',
+  html: 'text/html',
+  htm: 'text/html',
+  svg: 'image/svg+xml',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  webp: 'image/webp',
+  gif: 'image/gif',
+  pdf: 'application/pdf',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  mp4: 'video/mp4',
+  webm: 'video/webm'
+};
+
+const TEXT_EXTENSIONS = new Set(['txt', 'json', 'js', 'ts', 'css', 'html', 'htm']);
+const TEXT_MIME_TYPES = new Set([
+  'application/json',
+  'application/javascript',
+  'application/typescript',
+  'text/javascript',
+  'text/css',
+  'text/html',
+  'application/xml',
+  'text/xml'
+]);
+
+const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
+
+export function inferMimeType(extension = '') {
+  const normalized = extension ? extension.toLowerCase() : '';
+  if (!normalized) {
+    return 'text/plain';
+  }
+  return EXTENSION_MIME_MAP[normalized] || 'application/octet-stream';
+}
+
+function determineRenderMode(mimeType = '', extension = '') {
+  const normalizedMime = mimeType.toLowerCase();
+  const normalizedExt = (extension || '').toLowerCase();
+
+  if (normalizedExt === 'md' || normalizedMime === 'text/markdown') {
+    return 'markdown';
+  }
+  if (normalizedMime.startsWith('image/')) {
+    return 'image';
+  }
+  if (normalizedMime.startsWith('audio/')) {
+    return 'audio';
+  }
+  if (normalizedMime.startsWith('video/')) {
+    return 'video';
+  }
+  if (normalizedMime === 'application/pdf' || normalizedExt === 'pdf') {
+    return 'pdf';
+  }
+  if (normalizedMime.startsWith('text/')) {
+    return 'text';
+  }
+  if (TEXT_EXTENSIONS.has(normalizedExt) || TEXT_MIME_TYPES.has(normalizedMime)) {
+    return 'text';
+  }
+  return 'binary';
+}
+
+function isTextRenderMode(renderMode) {
+  return renderMode === 'text' || renderMode === 'markdown';
+}
+
+function detectContentMode(entry = {}) {
+  if (entry.contentMode === 'data' || entry.contentMode === 'url') {
+    return entry.contentMode;
+  }
+
+  const content = entry.content || '';
+  if (typeof content === 'string' && content.trim().startsWith('data:')) {
+    return 'data';
+  }
+
+  if (typeof content === 'string' && /^https?:\/\//i.test(content)) {
+    return 'url';
+  }
+
+  return 'data';
+}
+
+function base64ToUint8Array(base64) {
+  const binary = atob(base64);
+  const len = binary.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function parseDataUri(content) {
+  const commaIndex = content.indexOf(',');
+  if (commaIndex === -1) {
+    return {
+      mimeType: inferMimeType(),
+      data: content,
+      isBase64: false
+    };
+  }
+
+  const meta = content.slice(5, commaIndex);
+  const data = content.slice(commaIndex + 1);
+  const parts = meta.split(';').filter(Boolean);
+  const mimeType = parts[0] || 'text/plain';
+  const isBase64 = parts.includes('base64');
+  return { mimeType, data, isBase64 };
+}
+
+function decodeTextPayload(data, isBase64) {
+  if (isBase64) {
+    return textDecoder.decode(base64ToUint8Array(data));
+  }
+  return decodeURIComponent(data);
+}
+
+function decodeBinaryPayload(data, isBase64) {
+  if (isBase64) {
+    return base64ToUint8Array(data).buffer;
+  }
+  const decoded = decodeURIComponent(data);
+  return textEncoder.encode(decoded).buffer;
+}
+
+function loadFromData(entry) {
+  const content = entry?.content;
+  if (!content) {
+    throw new Error(`File "${entry?.name || 'untitled'}" has no data to render.`);
+  }
+
+  if (typeof content === 'string' && content.startsWith('data:')) {
+    const { mimeType, data, isBase64 } = parseDataUri(content);
+    const renderMode = determineRenderMode(mimeType, entry?.exten);
+    const rawData = isTextRenderMode(renderMode)
+      ? decodeTextPayload(data, isBase64)
+      : decodeBinaryPayload(data, isBase64);
+    return {
+      mimeType,
+      rawData,
+      renderMode
+    };
+  }
+
+  const mimeType = inferMimeType(entry?.exten);
+  const renderMode = determineRenderMode(mimeType, entry?.exten);
+  const rawData = isTextRenderMode(renderMode) ? content : textEncoder.encode(content).buffer;
+  return {
+    mimeType,
+    rawData,
+    renderMode
+  };
+}
+
+async function loadFromUrl(entry) {
+  const url = entry?.assetUrl || entry?.asset?.url || entry?.content;
+  if (!url) {
+    throw new Error(`Missing asset URL for "${entry?.name || 'file'}".`);
+  }
+
+  const response = await fetch(url, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch file: ${response.status} ${response.statusText}`);
+  }
+
+  const headerMime = response.headers.get('Content-Type');
+  const mimeType = headerMime?.split(';')[0]?.trim() || inferMimeType(entry?.exten);
+  const renderMode = determineRenderMode(mimeType, entry?.exten);
+  const rawData = isTextRenderMode(renderMode) ? await response.text() : await response.arrayBuffer();
+  return {
+    mimeType,
+    rawData,
+    renderMode,
+    sourceUrl: url
+  };
+}
+
+export async function loadFileContents(entry) {
+  if (!entry) {
+    throw new Error('No file entry provided.');
+  }
+
+  const mode = detectContentMode(entry);
+  if (mode === 'url') {
+    return loadFromUrl(entry);
+  }
+
+  return loadFromData(entry);
+}

--- a/src/components/utilities/fileLoader.js
+++ b/src/components/utilities/fileLoader.js
@@ -137,10 +137,8 @@ function decodeBinaryPayload(data, isBase64) {
 }
 
 function loadFromData(entry) {
-  const content = entry?.content;
-  if (!content) {
-    throw new Error(`File "${entry?.name || 'untitled'}" has no data to render.`);
-  }
+  const hasContent = entry?.content !== undefined && entry?.content !== null;
+  const content = hasContent ? entry.content : '';
 
   if (typeof content === 'string' && content.startsWith('data:')) {
     const { mimeType, data, isBase64 } = parseDataUri(content);
@@ -157,7 +155,17 @@ function loadFromData(entry) {
 
   const mimeType = inferMimeType(entry?.exten);
   const renderMode = determineRenderMode(mimeType, entry?.exten);
-  const rawData = isTextRenderMode(renderMode) ? content : textEncoder.encode(content).buffer;
+  const rawData = isTextRenderMode(renderMode)
+    ? content
+    : textEncoder.encode(String(content || '')).buffer;
+  if (!hasContent && !isTextRenderMode(renderMode)) {
+    // Provide an empty ArrayBuffer so downstream renderers don't crash.
+    return {
+      mimeType,
+      rawData: new ArrayBuffer(0),
+      renderMode
+    };
+  }
   return {
     mimeType,
     rawData,

--- a/src/components/utilities/makeFileItems.js
+++ b/src/components/utilities/makeFileItems.js
@@ -1,16 +1,41 @@
+function deriveContentMode(file) {
+    const mode = file?.contentMode || file?.content_mode;
+    if (mode === 'data' || mode === 'url') {
+        return mode;
+    }
+
+    const content = file?.content || '';
+    if (typeof content === 'string' && content.trim().startsWith('data:')) {
+        return 'data';
+    }
+
+    if (/^https?:\/\//i.test(content)) {
+        return 'url';
+    }
+
+    return 'data';
+}
+
+function toFileObject(f) {
+    const contentMode = deriveContentMode(f);
+    return {
+        object: f,
+        type: "f",
+        name: f.name,
+        exten: f.extension_abbr,
+        content: f.content,
+        contentMode,
+        assetUrl: contentMode === 'url' ? f.content : null,
+        is_shortcut: f.is_shortcut,
+        is_link: f.is_link
+    };
+}
+
 export function makeFileItems (files) {
     const contentsList = [];
     for (let i = 0; i < files.size(); i++) {
         const f = files.get(i);
-        contentsList.push({ 
-            object: f, 
-            type: "f", 
-            name: f.name, 
-            exten: f.extension_abbr, 
-            content: f.content, 
-            is_shortcut: f.is_shortcut,
-            is_link: f.is_link
-        });
+        contentsList.push(toFileObject(f));
 
     }
 
@@ -18,18 +43,8 @@ export function makeFileItems (files) {
 };
 
 export function makeFileItem (f) {
-   
-    const file_object = { 
-        object: f, 
-        type: "f", 
-        name: f.name, 
-        exten: f.extension_abbr, 
-        content: f.content, 
-        is_shortcut: f.is_shortcut,
-        is_link: f.is_link
-    };
 
-    return file_object;
+    return toFileObject(f);
 };
 
 

--- a/src/components/utilities/makeFileItems.js
+++ b/src/components/utilities/makeFileItems.js
@@ -1,3 +1,12 @@
+function extractAssetUrl(file) {
+    return (
+        file?.assetUrl ||
+        file?.asset_url ||
+        file?.asset?.url ||
+        null
+    );
+}
+
 function deriveContentMode(file) {
     const mode = file?.contentMode || file?.content_mode;
     if (mode === 'data' || mode === 'url') {
@@ -9,7 +18,11 @@ function deriveContentMode(file) {
         return 'data';
     }
 
-    if (/^https?:\/\//i.test(content)) {
+    if (typeof content === 'string' && /^https?:\/\//i.test(content)) {
+        return 'url';
+    }
+
+    if (extractAssetUrl(file)) {
         return 'url';
     }
 
@@ -17,6 +30,7 @@ function deriveContentMode(file) {
 }
 
 function toFileObject(f) {
+    const assetUrl = extractAssetUrl(f);
     const contentMode = deriveContentMode(f);
     return {
         object: f,
@@ -25,7 +39,8 @@ function toFileObject(f) {
         exten: f.extension_abbr,
         content: f.content,
         contentMode,
-        assetUrl: contentMode === 'url' ? f.content : null,
+        assetUrl: assetUrl || (contentMode === 'url' ? f.content : null),
+        asset: f.asset,
         is_shortcut: f.is_shortcut,
         is_link: f.is_link
     };

--- a/src/components/utilities/useExportFile.js
+++ b/src/components/utilities/useExportFile.js
@@ -1,10 +1,14 @@
 
-const importJsPdf = async () => {
-  const { jsPDF } = await import('jspdf');
-  return jsPDF;
-}
+let JsPdfConstructor = null;
 
-let jsPDF = null;
+const ensureJsPdf = async () => {
+  if (!JsPdfConstructor) {
+    const { jsPDF } = await import('jspdf');
+    JsPdfConstructor = jsPDF;
+  }
+
+  return JsPdfConstructor;
+}
 
 const emojiToImg = (emoji) => {
   const canvas = document.createElement("canvas");
@@ -50,29 +54,35 @@ const replaceEmojisInNode = (node) => {
 };
 
 export function useExportFile() {
-  const downloadBase64 = (dataUrl, filename) => {
+  const saveBlob = (blob, filename) => {
+    const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
-    a.href = dataUrl;
+    a.href = url;
     a.download = filename;
     a.click();
+    URL.revokeObjectURL(url);
   };
 
-  const exportText = (base64Data, filename) => {
-    const decoded = atob(base64Data.split(',')[1]);
-    const doc = new jsPDF();
-    const lines = decoded.split('\n');
+  const exportPlainText = async (text, filename) => {
+    const JsPdf = await ensureJsPdf();
+    const doc = new JsPdf();
+    const lines = (text || '').split('\n');
     lines.forEach((line, i) => doc.text(line, 10, 10 + i * 7));
     doc.save(filename.replace(/\.\w+$/, '') + '.pdf');
   };
 
   const exportHTMLToPDF = async (elementSelector, filename) => {
-      
-    const el = document.querySelector(`#${CSS.escape(elementSelector)}`).cloneNode(true);
-    
-    if (!el) {
+
+    const JsPdf = await ensureJsPdf();
+
+    const element = document.querySelector(`#${CSS.escape(elementSelector)}`);
+
+    if (!element) {
       console.warn('Element not found for export:', elementSelector);
       return;
     }
+
+    const el = element.cloneNode(true);
 
     // Create an off-screen container to render it for jsPDF
     const container = document.createElement('div');
@@ -86,7 +96,7 @@ export function useExportFile() {
     // Replace inline emoji characters with images
     replaceEmojisInNode(el);
 
-    const doc = new jsPDF({
+    const doc = new JsPdf({
       orientation: 'p',
       unit: 'px',
       format: 'a4',
@@ -114,21 +124,49 @@ export function useExportFile() {
     await exportHTMLToPDF(id, name);
   };
 
+  const createBlobFromRenderable = (renderableFile) => {
+    if (!renderableFile) {
+      throw new Error('Nothing to export yet.');
+    }
 
-  const exportGeneric = (dataUrl, filename) => {
-    downloadBase64(dataUrl, filename);
+    if (renderableFile.rawData instanceof ArrayBuffer) {
+      return new Blob([renderableFile.rawData], { type: renderableFile.mimeType || 'application/octet-stream' });
+    }
+
+    if (renderableFile.rawData instanceof Blob) {
+      return renderableFile.rawData;
+    }
+
+    if (typeof renderableFile.rawData === 'string') {
+      return new Blob([renderableFile.rawData], { type: renderableFile.mimeType || 'text/plain' });
+    }
+
+    throw new Error('Unsupported file format for export.');
   };
 
-  const exportFile = async ({ id, content, exten, name }) => {
-    jsPDF = await importJsPdf();
-    const ext = exten.toLowerCase();
-    if (ext === 'md') {
-      await exportMarkdownAsPDF(id, name);
-    } else if (['txt', 'json', 'html', 'css', 'js', 'cpp', 'h'].includes(ext)) {
-      exportText(content, name);
-    } else {
-      exportGeneric(content, name);
+  const exportBinary = (renderableFile, filename) => {
+    const blob = createBlobFromRenderable(renderableFile);
+    saveBlob(blob, filename);
+  };
+
+  const exportFile = async ({ id, renderableFile, exten, name }) => {
+    if (!renderableFile) {
+      console.warn('Attempted to export before the file finished loading.');
+      return;
     }
+
+    const ext = (exten || '').toLowerCase();
+    if (renderableFile.renderMode === 'markdown' || ext === 'md') {
+      await exportMarkdownAsPDF(id, name);
+      return;
+    }
+
+    if (renderableFile.renderMode === 'text' || ['txt', 'json', 'html', 'css', 'js', 'ts', 'cpp', 'h'].includes(ext)) {
+      await exportPlainText(typeof renderableFile.rawData === 'string' ? renderableFile.rawData : '', name);
+      return;
+    }
+
+    exportBinary(renderableFile, name);
   };
 
   return { exportFile };

--- a/src/components/views/FileViewerView.vue
+++ b/src/components/views/FileViewerView.vue
@@ -1,124 +1,198 @@
 <template>
   <div class="doc-viewer">
-    <!-- Handle different file types -->
-    <div v-if="isTextFile" class="page-content-container">
-      <div  class="page-content" v-html="renderDecodedContent()"></div>
+    <div v-if="loading" class="page-content-container">
+      <div class="page-content">Loading file…</div>
     </div>
 
-    <img v-else-if="isImageFile" :src="content" alt="Image preview" class="image-preview" />
-    <video v-else-if="isVideoFile" :src="content" controls class="video-preview"></video>
-    <audio v-else-if="isAudioFile" :src="content" controls class="audio-preview"></audio>
+    <div v-else-if="error" class="page-content-container">
+      <div class="page-content unsupported">{{ error }}</div>
+    </div>
 
-    <div v-else-if="isMarkdown" class="page-content-container">
-      <div :id="id" class="page-content" v-html="renderMarkdown()"></div>
-    </div>
-    <div v-else class="unsupported">
-      Unsupported file type: {{ file_ext }}
-    </div>
+    <template v-else>
+      <div v-if="renderer.mode === 'text'" class="page-content-container">
+        <div class="page-content" v-html="renderer.content"></div>
+      </div>
+
+      <div v-else-if="renderer.mode === 'markdown'" class="page-content-container">
+        <div :id="id" class="page-content" v-html="renderer.content"></div>
+      </div>
+
+      <img v-else-if="renderer.mode === 'image'" :src="renderer.source" alt="Image preview" class="image-preview" />
+      <video v-else-if="renderer.mode === 'video'" :src="renderer.source" controls class="video-preview"></video>
+      <audio v-else-if="renderer.mode === 'audio'" :src="renderer.source" controls class="audio-preview"></audio>
+      <iframe v-else-if="renderer.mode === 'pdf'" :src="renderer.source" class="pdf-frame"></iframe>
+
+      <div v-else class="unsupported">
+        Unsupported file type: {{ file.exten || 'unknown' }}
+      </div>
+    </template>
   </div>
 </template>
 
-<script>
+<script setup>
 import { marked } from 'marked';
 import { markedEmoji } from 'marked-emoji';
+import { onBeforeUnmount, ref, watch } from 'vue';
 
-import { extractAndDecodeBase64 } from '@/components/utilities/decode'
+import { loadFileContents } from '@/components/utilities/fileLoader';
 
-export default {
-  props: {
-    id: {
-      type: String,
-      required: true
-    },
-    content: {
-      type: String, // Base64 data URI for binary files or raw text
-      required: true,
-    },
-    name: {
-      type: String,
-      default: "File_Name",
-    },
-    file_ext: {
-      type: String, // File extension (e.g., 'txt', 'png', 'mp3')
-      required: true,
-    },
+const props = defineProps({
+  id: {
+    type: String,
+    required: true
   },
-  computed: {
-    isTextFile() {
-      return ['txt', 'json', 'html', 'css', 'js', 'cpp', 'h', ''].includes(this.file_ext.toLowerCase());
-    },
-    isImageFile() {
-      return ['jpg', 'jpeg', 'png', 'gif', 'svg', 'webp'].includes(this.file_ext.toLowerCase());
-    },
-    isVideoFile() {
-      return ['mp4', 'webm', 'ogg', 'mov'].includes(this.file_ext.toLowerCase());
-    },
-    isAudioFile() {
-      return ['mp3', 'wav', 'ogg', 'm4a'].includes(this.file_ext.toLowerCase());
-    },
-    isMarkdown() {
-      return this.file_ext.toLowerCase() == 'md';
-    }
-  },
-  methods: {
-    renderDecodedContent() {
-    const decodedText = extractAndDecodeBase64(this.content);
-    return decodedText.replace(/\n/g, "<br>");
-    },
-    renderMarkdown() {
-      // Ensure links open in a new tab
-        const renderer = new marked.Renderer();
-        renderer.link = function (href, title, text) {
-          var link = marked.Renderer.prototype.link.call(this, href, title, text);
-          return link.replace("<a","<a target='_blank' ");
-        }
-
-        // Emoji options for marked
-        const emojiOptions = {
-        emojis: {
-          "star": "🌟",
-          "chili": "🌶️",
-          "laptop": "💻",
-          "rainbow": "🌈",
-          "briefcase": "💼",
-          "woman_technologist": "👩🏽‍💻",
-          "heart": "❤️",
-          "tada": "🎉",
-          // add new ones from README
-          "arrow_right": "➡️",
-          "computer": "🖥️",
-          "mag": "🔍",
-          "handshake": "🤝"
-        },
-        renderer: (token) => token.emoji,
-      };
-
-
-      // Apply emoji options (only once)
-      if (!marked.extensions?.emojiApplied) {
-        marked.use(markedEmoji(emojiOptions));
-        marked.extensions = { ...marked.extensions, emojiApplied: true };
-      }
-
-      // Decode Base64 content and parse Markdown
-      try {
-        const decodedContent = extractAndDecodeBase64(this.content);
-        return marked.parse(decodedContent, { renderer });
-      } catch (error) {
-        console.error("Error decoding Base64 content:", error);
-        return "<p>Invalid content provided.</p>";
-      }
-    }
-
+  file: {
+    type: Object,
+    required: true
   }
+});
+
+const emit = defineEmits(['loaded']);
+
+const loading = ref(true);
+const error = ref(null);
+const renderer = ref({ mode: 'loading' });
+const activeObjectUrl = ref(null);
+let loadToken = 0;
+
+const markdownRenderer = new marked.Renderer();
+markdownRenderer.link = function (href, title, text) {
+  const link = marked.Renderer.prototype.link.call(this, href, title, text);
+  return link.replace('<a', "<a target='_blank' ");
 };
+
+const emojiOptions = {
+  emojis: {
+    star: '🌟',
+    chili: '🌶️',
+    laptop: '💻',
+    rainbow: '🌈',
+    briefcase: '💼',
+    woman_technologist: '👩🏽‍💻',
+    heart: '❤️',
+    tada: '🎉',
+    arrow_right: '➡️',
+    computer: '🖥️',
+    mag: '🔍',
+    handshake: '🤝'
+  },
+  renderer: (token) => token.emoji
+};
+
+if (!marked.__spicyEmojiApplied) {
+  marked.use(markedEmoji(emojiOptions));
+  marked.__spicyEmojiApplied = true;
+}
+
+watch(
+  () => props.file,
+  () => {
+    hydrateFile();
+  },
+  { immediate: true }
+);
+
+async function hydrateFile() {
+  const token = ++loadToken;
+  loading.value = true;
+  error.value = null;
+  renderer.value = { mode: 'loading' };
+  cleanupObjectUrl();
+
+  try {
+    const renderableFile = await loadFileContents(props.file);
+    if (token !== loadToken) {
+      return;
+    }
+    renderer.value = renderFile(renderableFile);
+    emit('loaded', renderableFile);
+  } catch (err) {
+    if (token !== loadToken) {
+      return;
+    }
+    console.error('Failed to load file', err);
+    error.value = err?.message || 'Failed to load file.';
+  } finally {
+    if (token === loadToken) {
+      loading.value = false;
+    }
+  }
+}
+
+function renderFile(file) {
+  if (!file) {
+    return { mode: 'unsupported' };
+  }
+
+  if (file.renderMode === 'markdown') {
+    return { mode: 'markdown', content: renderMarkdownContent(file.rawData) };
+  }
+
+  if (file.renderMode === 'text') {
+    return { mode: 'text', content: formatTextContent(file.rawData) };
+  }
+
+  if (['image', 'audio', 'video', 'pdf'].includes(file.renderMode)) {
+    return { mode: file.renderMode, source: getMediaSource(file) };
+  }
+
+  return { mode: 'unsupported' };
+}
+
+function formatTextContent(raw) {
+  if (typeof raw !== 'string') {
+    return '';
+  }
+  return raw.replace(/\n/g, '<br>');
+}
+
+function renderMarkdownContent(raw) {
+  const value = typeof raw === 'string' ? raw : '';
+  try {
+    return marked.parse(value, { renderer: markdownRenderer });
+  } catch (err) {
+    console.error('Error rendering markdown', err);
+    return '<p>Invalid content provided.</p>';
+  }
+}
+
+function cleanupObjectUrl() {
+  if (activeObjectUrl.value) {
+    URL.revokeObjectURL(activeObjectUrl.value);
+    activeObjectUrl.value = null;
+  }
+}
+
+function getMediaSource(file) {
+  cleanupObjectUrl();
+  const { rawData, mimeType, sourceUrl } = file;
+
+  if (typeof rawData === 'string') {
+    if (rawData.startsWith('data:') || /^https?:\/\//i.test(rawData)) {
+      return rawData;
+    }
+    return sourceUrl || rawData;
+  }
+
+  if (rawData instanceof ArrayBuffer) {
+    const blob = new Blob([rawData], { type: mimeType || 'application/octet-stream' });
+    activeObjectUrl.value = URL.createObjectURL(blob);
+    return activeObjectUrl.value;
+  }
+
+  return sourceUrl || '';
+}
+
+onBeforeUnmount(() => {
+  cleanupObjectUrl();
+});
 </script>
 
 <style>
 @reference '../../style.css';
 
 .doc-viewer {
-  @apply w-full h-full flex flex-col items-center p-0; /* Container for all file previews */
+  @apply w-full h-full flex flex-col items-center p-0;
 }
 
 .page-content-container {
@@ -130,27 +204,31 @@ export default {
 }
 
 .page-content {
-  @apply relative text-primary-dark-base p-8 h-full overflow-auto; /* Styling for text content */
-  filter: brightness(0.5); /* Neutralize brightness for text */
+  @apply relative text-primary-dark-base p-8 h-full overflow-auto;
+  filter: brightness(0.5);
   line-height: 1.8rem;
-  
 }
 
 .image-preview {
-  @apply w-auto h-auto max-w-full max-h-full p-3; /* Ensures the image maintains aspect ratio */
-  object-fit: contain; /* Ensures the image fits within its container while keeping aspect ratio */
-  display: block; /* Prevent inline gaps */
+  @apply w-auto h-auto max-w-full max-h-full p-3;
+  object-fit: contain;
+  display: block;
   filter: brightness(0.5);
 }
 
 .video-preview,
 .audio-preview {
-  @apply w-full max-w-4xl; /* Styling for videos and audio */
+  @apply w-full max-w-4xl;
   filter: brightness(0.5);
 }
 
+.pdf-frame {
+  @apply w-full h-full border-none;
+  background-color: #111827;
+}
+
 .unsupported {
-  @apply text-red-500 font-bold; /* Styling for unsupported file types */
+  @apply text-red-500 font-bold;
 }
 
 .page-content ul {
@@ -181,13 +259,9 @@ export default {
   @apply pb-3;
 }
 
-
-
-
 @media (max-width: 768px) {
   .image-preview {
-    @apply max-w-full max-h-[80vh]; /* Adjust image size for smaller screens */
+    @apply max-w-full max-h-[80vh];
   }
 }
 </style>
-

--- a/src/components/windows/FileWindow.vue
+++ b/src/components/windows/FileWindow.vue
@@ -1,11 +1,10 @@
 <template>
   <BaseWindow v-bind="baseWindowProps" @export="downloadFile"
   :class="{'cursor-pointer': isMini}">
-    <FileViewerView 
-      :content="item.content"
-      :file_ext="item.exten"
-      :name="item.name"
+    <FileViewerView
+      :file="item"
       :id="fileId"
+      @loaded="handleFileLoaded"
     />
   </BaseWindow>
 </template>
@@ -51,10 +50,20 @@ const handleMinimize = (bool) => {
 
 const getMaximized = () => appsStore.isFileMaximized(props.item)
 const getMinimized = () => appsStore.isFileMinimized(props.item)
+const loadedRenderableFile = ref(null)
+const handleFileLoaded = (file) => {
+  loadedRenderableFile.value = file
+}
+
 const downloadFile = async () => {
+  if (!loadedRenderableFile.value) {
+    console.warn('File is still loading, please try exporting again once it is ready.')
+    return
+  }
+
   await exportFile({
     id: fileId,
-    content: props.item.content,
+    renderableFile: loadedRenderableFile.value,
     exten: props.item.exten,
     name: props.item.name
   })


### PR DESCRIPTION
## Summary
- add a reusable file loading utility that can infer MIME types and return renderable file descriptors
- update the desktop file viewer and window plumbing to hydrate files via the new loader and render based on render mode
- refresh the export pipeline to work with dynamically loaded content

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69197baf6708832fbb02b7110eed233c)