### PR TITLE
Fix browser links opening

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -39,6 +39,10 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+        env:
+          VITE_SANITY_PROJECT_ID: ${{ secrets.VITE_SANITY_PROJECT_ID }}
+          VITE_SANITY_DATASET: ${{ secrets.VITE_SANITY_DATASET }}
+          VITE_SANITY_API_VERSION: ${{ secrets.VITE_SANITY_API_VERSION }}
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact

--- a/src/components/utilities/decode.js
+++ b/src/components/utilities/decode.js
@@ -25,6 +25,15 @@ function decodeBase64(base64) {
  * @returns {string} - Decoded HTML string
  */
 export function extractAndDecodeBase64(content) {
+  if (!content || typeof content !== 'string') {
+    return "";
+  }
+
+  // Pass through plain URLs/strings instead of trying to decode them.
+  if (!content.trim().startsWith('data:')) {
+    return content;
+  }
+
   const base64 = extractBase64Data(content);
   if (!base64) return "";
   const decoded = decodeBase64(base64);


### PR DESCRIPTION
## Summary
- allow browser windows to accept direct URLs by skipping base64 decoding when the link content is not a data URI

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a63cd257c832facd4dd2d7b1c6c3f)