### PR TITLE
Add Projects directory wiring to file manager

### DIFF
--- a/shell_src_for_emcc/FileManagerContext.cpp
+++ b/shell_src_for_emcc/FileManagerContext.cpp
@@ -89,6 +89,10 @@ FileSystem::Directory* FileManagerContext::get_desktop_dir_ptr() const {
     return this->fs->get_desktop_dir_ptr();
 }
 
+FileSystem::Directory* FileManagerContext::get_projects_dir_ptr() const {
+    return this->fs->get_projects_dir_ptr();
+}
+
 void FileManagerContext::reset(FileSystem::Directory* dir) {
     this->forward_history.clear();
     this->back_history.clear();

--- a/shell_src_for_emcc/FileManagerContext.h
+++ b/shell_src_for_emcc/FileManagerContext.h
@@ -39,6 +39,7 @@ public:
     FileSystem::Directory* get_root_dir_ptr() const;
     FileSystem::Directory* get_documents_dir_ptr() const;
     FileSystem::Directory* get_desktop_dir_ptr() const;
+    FileSystem::Directory* get_projects_dir_ptr() const;
     
 private:
     FileSystem::Directory* cur_dir;

--- a/shell_src_for_emcc/SystemCore.cpp
+++ b/shell_src_for_emcc/SystemCore.cpp
@@ -64,6 +64,10 @@ FileSystem::Directory* SystemCore::get_desktop_dir_ptr() const {
     return this->f.get_desktop_dir_ptr();
 }
 
+FileSystem::Directory* SystemCore::get_projects_dir_ptr() const {
+    return this->f.get_projects_dir_ptr();
+}
+
 void SystemCore::reset_filesystem_state() {
     FileSystem::Directory* start = this->fs->get_home_dir_ptr();
     if (!start) {

--- a/shell_src_for_emcc/SystemCore.h
+++ b/shell_src_for_emcc/SystemCore.h
@@ -30,6 +30,7 @@ public:
     FileSystem::Directory* get_root_dir_ptr() const;
     FileSystem::Directory* get_documents_dir_ptr() const;
     FileSystem::Directory* get_desktop_dir_ptr() const;
+    FileSystem::Directory* get_projects_dir_ptr() const;
 
     FileSystem::Directory* get_cur_fs_dir();
     void reset_filesystem_state();

--- a/shell_src_for_emcc/filesystem/file_system.cpp
+++ b/shell_src_for_emcc/filesystem/file_system.cpp
@@ -9,6 +9,8 @@ FileSystem::FileSystem(const std::string &name, const std::string&root_name = "/
     this->pictures = nullptr;
     this->documents = nullptr;
     this->current_dir = this->root.get();
+    this->desktop = nullptr;
+    this->projects = nullptr;
 
 }
 
@@ -33,6 +35,10 @@ void FileSystem::set_desktop_dir_ptr(FileSystem::Directory* p){
     this->desktop = p;
 }
 
+void FileSystem::set_projects_dir_ptr(FileSystem::Directory* p){
+    this->projects = p;
+}
+
 FileSystem::Directory* FileSystem::get_home_dir_ptr() const {
     return this->home;
 }
@@ -55,6 +61,10 @@ FileSystem::Directory* FileSystem::get_documents_dir_ptr() const {
 
 FileSystem::Directory* FileSystem::get_desktop_dir_ptr() const {
     return this->desktop;
+}
+
+FileSystem::Directory* FileSystem::get_projects_dir_ptr() const {
+    return this->projects;
 }
 
 std::string FileSystem::get_home_dir(){

--- a/shell_src_for_emcc/filesystem/file_system.h
+++ b/shell_src_for_emcc/filesystem/file_system.h
@@ -126,6 +126,7 @@ public:
     void set_pictures_dir_ptr(Directory* p);
     void set_documents_dir_ptr(Directory* p);
     void set_desktop_dir_ptr(Directory *p);
+    void set_projects_dir_ptr(Directory *p);
 
     Directory* get_home_dir_ptr() const;
     Directory* get_downloads_dir_ptr() const;
@@ -133,6 +134,7 @@ public:
     Directory* get_root_dir_ptr() const;
     Directory* get_documents_dir_ptr() const;
     Directory* get_desktop_dir_ptr() const;
+    Directory* get_projects_dir_ptr() const;
 
     /**
      * @brief Sets the home directory.
@@ -232,6 +234,7 @@ private:
     Directory* pictures; /** Pointer to picures directory. */
     Directory* documents; /** Pointer to documents directory. */
     Directory* desktop; /** Pointer to desktop directory. */
+    Directory* projects; /** Pointer to projects directory. */
 
 
     Directory *current_dir; /** Pointer to current working directory. */

--- a/shell_src_for_emcc/filesystem/initialize_spcy_fs.cpp
+++ b/shell_src_for_emcc/filesystem/initialize_spcy_fs.cpp
@@ -289,6 +289,11 @@ void register_role(FileSystem &fs, const std::string &role, Directory *dir) {
         return;
     }
 
+    if (role == "projects") {
+        fs.set_projects_dir_ptr(dir);
+        return;
+    }
+
     if (role == "bin") {
         const std::string path = fs.get_dir_path(dir);
         if (!fs.PATH.empty()) {
@@ -409,6 +414,7 @@ void loadFilesystemFromManifest(std::shared_ptr<FileSystem> fs, const emscripten
     fs->set_pictures_dir_ptr(nullptr);
     fs->set_documents_dir_ptr(nullptr);
     fs->set_desktop_dir_ptr(nullptr);
+    fs->set_projects_dir_ptr(nullptr);
     fs->PATH.clear();
 
     if (has_property(manifest_json, "root")) {

--- a/shell_src_for_emcc/system.cpp
+++ b/shell_src_for_emcc/system.cpp
@@ -75,6 +75,10 @@ FileSystem::Directory* get_desktop_dir_ptr() {
     return s.get_desktop_dir_ptr();
 }
 
+FileSystem::Directory* get_projects_dir_ptr() {
+    return s.get_projects_dir_ptr();
+}
+
 FileSystem::Directory::File* resolve_shortcut(FileSystem::Directory::File* f) {
     return (f && f->is_shortcut) ? f->shortcut_target.lock().get() : nullptr;
 }
@@ -130,6 +134,7 @@ EMSCRIPTEN_BINDINGS(file_manager) {
     emscripten::function("get_root_dir_ptr", &get_root_dir_ptr, emscripten::allow_raw_pointers());
     emscripten::function("get_documents_dir_ptr", &get_documents_dir_ptr, emscripten::allow_raw_pointers());
     emscripten::function("get_desktop_dir_ptr", &get_desktop_dir_ptr, emscripten::allow_raw_pointers());
+    emscripten::function("get_projects_dir_ptr", &get_projects_dir_ptr, emscripten::allow_raw_pointers());
 
     emscripten::function("resolve_shortcut", &resolve_shortcut, emscripten::allow_raw_pointers());
 

--- a/src/assets/js/terminal/terminal.js
+++ b/src/assets/js/terminal/terminal.js
@@ -5,11 +5,11 @@ import "@xterm/xterm/css/xterm.css";
 import { useIsMobile } from "@/components/utilities/useIsMobile";
 
 // Function to initialize the terminal
-export function initializeTerminal(terminalContainer, parentWindow) {
-    const term = terminalSetup(terminalContainer, parentWindow);
+export function initializeTerminal(terminalContainer, windowControls = {}) {
+    const term = terminalSetup(terminalContainer, windowControls);
 
     SystemModule.set_terminal(term);
-  
+
 }
 
 function printIntro(art, terminal) {
@@ -32,7 +32,7 @@ Type 'help' to get started.      \r\n
 `;
 
 
-function terminalSetup(terminalContainer, parentWindow) {
+function terminalSetup(terminalContainer, windowControls) {
     let fontSize = 16;
     const {isMobile} = useIsMobile();
     if (isMobile.value) fontSize = 12;
@@ -118,7 +118,7 @@ function terminalSetup(terminalContainer, parentWindow) {
             cursorPosition = 0;
             if (inputBuffer.length !== 0) {
                 if (inputBuffer == 'exit'){
-                    parentWindow.closeApp();
+                    windowControls.closeApp?.();
                 }
                 // Add command to history (if not duplicate of the last command)
                 if (commandHistory.length === 0 || commandHistory[commandHistory.length - 1] !== inputBuffer) {

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -142,8 +142,19 @@ setup() {
         return null;
       }
 
-      const homeChildren = SystemModule.list_directories(homeDir) || [];
-      return homeChildren.find((dir) => dir?.name?.toLowerCase?.() === "projects") || null;
+      const homeChildren = SystemModule.list_directories(homeDir);
+      if (!homeChildren || typeof homeChildren.size !== "function") {
+        return null;
+      }
+
+      for (let i = 0; i < homeChildren.size(); i++) {
+        const childDir = homeChildren.get(i);
+        if (childDir?.name?.toLowerCase?.() === "projects") {
+          return childDir;
+        }
+      }
+
+      return null;
     };
 
     const projects_ptr = resolveProjectsDirPtr();

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -127,20 +127,37 @@ setup() {
 
 
     const downloads_ptr = SystemModule.get_downloads_dir_ptr();
-    const home_ptr = SystemModule.get_home_dir_ptr();
     const documents_ptr = SystemModule.get_documents_dir_ptr();
     const pictures_ptr = SystemModule.get_pictures_dir_ptr();
     const desktop_ptr = SystemModule.get_desktop_dir_ptr();
     const root_ptr = SystemModule.get_root_dir_ptr();
 
-    const sidebarDirs = ref([
-    { name: "Home", ptr: home_ptr },
-    { name: "Desktop", ptr: desktop_ptr },
-    { name: "Downloads", ptr: downloads_ptr },
-    { name: "Documents", ptr: documents_ptr },
-    { name: "Pictures", ptr: pictures_ptr },
-    { name: "Root", ptr: root_ptr }
-    ]);
+    const resolveProjectsDirPtr = () => {
+      if (typeof SystemModule.get_projects_dir_ptr === "function") {
+        return SystemModule.get_projects_dir_ptr();
+      }
+
+      const homeDir = SystemModule.get_home_dir_ptr();
+      if (!homeDir || typeof SystemModule.list_directories !== "function") {
+        return null;
+      }
+
+      const homeChildren = SystemModule.list_directories(homeDir) || [];
+      return homeChildren.find((dir) => dir?.name?.toLowerCase?.() === "projects") || null;
+    };
+
+    const projects_ptr = resolveProjectsDirPtr();
+
+    const sidebarDirs = ref(
+      [
+        { name: "Desktop", ptr: desktop_ptr },
+        { name: "Downloads", ptr: downloads_ptr },
+        { name: "Documents", ptr: documents_ptr },
+        { name: "Pictures", ptr: pictures_ptr },
+        { name: "Projects", ptr: projects_ptr },
+        { name: "Root", ptr: root_ptr }
+      ].filter((dir) => !!dir.ptr)
+    );
 
     return {
       contents,
@@ -151,11 +168,11 @@ setup() {
       forward,
       openFile,
       downloads_ptr,
-      home_ptr,
       pictures_ptr,
       documents_ptr,
       root_ptr,
       desktop_ptr,
+      projects_ptr,
       directoryTitle,
       toRaw,
       sidebarDirs,

--- a/src/components/views/TerminalView.vue
+++ b/src/components/views/TerminalView.vue
@@ -3,33 +3,37 @@
     <div ref="terminalDiv" id="terminal"></div>
 </template>
 
-<script>
-import "@/assets/js/terminal/system.js"
-import { initializeTerminal } from '../../assets/js/terminal/terminal.js';
+<script setup>
+import { onMounted, ref } from "vue";
+import "@/assets/js/terminal/system.js";
+import { initializeTerminal } from "@/assets/js/terminal/terminal.js";
+import { useAppsStore } from "@/components/stores/apps";
 
-export default {
-   
-    mounted() {
-        this.initTerminal(); // Initialize the terminal after the component is mounted
+const props = defineProps({
+    contentType: {
+        type: String,
+        default: "terminal",
     },
+});
 
-    methods: {
-        initTerminal() {
-            // Access the terminal div using $refs
-            const contentElement = this.$refs.terminalDiv;
-            if (contentElement) {
-            
-                initializeTerminal(contentElement, this.$parent);  // Pass the terminal container as the argument
-            
-            }
-        },
+const terminalDiv = ref(null);
+const appsStore = useAppsStore();
 
-    },
+const initTerminal = () => {
+    const contentElement = terminalDiv.value;
+    if (!contentElement) return;
+
+    initializeTerminal(contentElement, {
+        closeApp: () => appsStore.closeApp(props.contentType || "terminal"),
+    });
 };
+
+onMounted(() => {
+    initTerminal();
+});
 </script>
 <style scoped>
 #terminal {
     @apply h-full w-full;
 }
 </style>
-

--- a/studio-spicyos/schemaTypes/portfolioManifest.ts
+++ b/studio-spicyos/schemaTypes/portfolioManifest.ts
@@ -44,6 +44,7 @@ export const remoteFolder = defineType({
           { title: 'Documents', value: 'documents' },
           { title: 'Downloads', value: 'downloads' },
           { title: 'Pictures', value: 'pictures' },
+          { title: 'Projects', value: 'projects' },
           { title: '/bin', value: 'bin' },
           { title: '/etc', value: 'etc' },
           { title: '/usr', value: 'usr' },


### PR DESCRIPTION
## Summary
- add a dedicated "Projects" system role in the schema plus the filesystem/wasm bindings so the pointer can be tracked
- expose the pointer to the frontend and update the file manager sidebar so Projects appears after Pictures while Home is removed
## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a6ea41668832f8b37fc4d046a7c7e)