### PR TITLE
Support browser links inside directories

### DIFF
--- a/src/components/utilities/openFile.js
+++ b/src/components/utilities/openFile.js
@@ -2,8 +2,19 @@ import { toRaw } from "vue";
 import { makeFileItem } from "@/components/utilities/makeFileItems";
 import { useAppsStore } from "@/components/stores/apps";
 
+const BROWSER_APP_ID = 'browser';
+
 export function openFile(item) {
   const appsStore = useAppsStore();
+
+  if (item.is_link) {
+    if (item.content) {
+      appsStore.openApp(BROWSER_APP_ID, { url: item.content });
+    } else {
+      console.warn('Attempted to open link file without content.', item);
+    }
+    return;
+  }
 
   if (item.is_shortcut) {
     const target = SystemModule.resolve_shortcut(toRaw(item.object));

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -50,7 +50,11 @@
             <Icon v-if="item.type === 'd'" :image="'directory'" class="d"/>
             <Icon v-else-if="item.type === 'f' && !item.is_shortcut && !item.is_link" :image="'file'" class="d" />
             <Icon v-else-if="item.type === 'f' && item.is_shortcut" :image="'shortcut'" class="d" />
-            <Icon v-else-if="item.type === 'f' && item.is_link" :image="'browserLink'" class="d" />
+            <Icon
+              v-else-if="item.type === 'f' && item.is_link"
+              :image="'browserLink'"
+              class="d link-highlight"
+            />
             <div class="file-info">
               <span class="file-name">{{ item.name }}</span>
             </div>
@@ -270,6 +274,16 @@ setup() {
 .d :deep(line),
 .d :deep(polygon),
 .d :deep(polyline) {
+  @apply stroke-black;
+}
+
+.link-highlight :deep(path),
+.link-highlight :deep(circle),
+.link-highlight :deep(ellipse),
+.link-highlight :deep(rect),
+.link-highlight :deep(line),
+.link-highlight :deep(polygon),
+.link-highlight :deep(polyline) {
   @apply stroke-accent-yellow-shadow;
 }
 

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -263,8 +263,14 @@ setup() {
   @apply overflow-auto max-h-full;
 }
 
-.d :deep(path) {
-  @apply stroke-black;
+.d :deep(path),
+.d :deep(circle),
+.d :deep(ellipse),
+.d :deep(rect),
+.d :deep(line),
+.d :deep(polygon),
+.d :deep(polyline) {
+  @apply stroke-accent-yellow-shadow;
 }
 
 .file-item {

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -41,14 +41,16 @@
       <div class="file-grid-container">
         <!-- Responsive Grid that Auto-adjusts -->
         <div class="file-grid">
-          <div 
-            v-for="item in contents" 
-            :key="item.name" 
+          <div
+            v-for="item in contents"
+            :key="item.name"
             class="file-item"
             @dblclick="item.type === 'd' ? chdir(toRaw(item.object)) : openFile(item)"
           >
             <Icon v-if="item.type === 'd'" :image="'directory'" class="d"/>
-            <Icon v-else-if="item.type === 'f'" :image="'file'" />
+            <Icon v-else-if="item.type === 'f' && !item.is_shortcut && !item.is_link" :image="'file'" class="d" />
+            <Icon v-else-if="item.type === 'f' && item.is_shortcut" :image="'shortcut'" class="d" />
+            <Icon v-else-if="item.type === 'f' && item.is_link" :image="'browserLink'" class="d" />
             <div class="file-info">
               <span class="file-name">{{ item.name }}</span>
             </div>


### PR DESCRIPTION
## Summary
- ensure the file manager renders unique icons for shortcuts and browser links so .lnk files stand out anywhere in the filesystem
- extend the shared openFile utility so link files open the built-in browser instead of the document viewer

## Testing
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a93d28540832fa5982c7f94ce4801)