### PR TITLE
Support directory shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ No Emscripten required unless you're going under the hood.
 
 If you're editing the manifest in Sanity, any entry whose `kind` is set to `shortcut` now exposes a `shortcutTargetPath` field. Point it at the absolute path of the file you want to open (e.g. `/home/SpicyKneecaps/Documents/Resume.md` or `~/Documents/Resume.md`). The WebAssembly loader resolves that path at boot so shortcuts behave like real desktop aliases without duplicating content. Paths with spaces are supported—either type the literal space or use shell-style escapes (e.g. `/Users/Zaria\ Burton/Documents/Resume.md`) and the loader will normalize them automatically.
 
+Need a shortcut that launches the File Manager in a folder instead? Flip the `shortcutTargetType` field to `directory`. SpicyOS will render the new folder shortcut icon on the desktop/File Manager, and double-clicking it opens the requested directory rather than a file preview window.
+
 ---
 
 ### ⚙️ Recompiling the Shell Backend (C++)

--- a/public/portfolioManifest.json
+++ b/public/portfolioManifest.json
@@ -2,4 +2,5 @@
       "kind": "shortcut",
       "content": "",
       "tags": [],
-      "shortcutTargetPath": "/home/SpicyKneecaps/Documents/Resume.md"
+      "shortcutTargetPath": "/home/SpicyKneecaps/Documents/Resume.md",
+      "shortcutTargetType": "file"

--- a/shell_src_for_emcc/filesystem/initialize_spcy_fs.cpp
+++ b/shell_src_for_emcc/filesystem/initialize_spcy_fs.cpp
@@ -319,6 +319,13 @@ std::shared_ptr<File> buildFile(const emscripten::val &entry) {
 
     auto file = std::make_shared<File>(name, extension, content);
     const std::string kind = to_lower(read_string(entry, "kind", "file"));
+    std::string shortcut_target_type = to_lower(read_string(entry, "shortcutTargetType"));
+    if (shortcut_target_type.empty()) {
+        shortcut_target_type = to_lower(read_string(entry, "shortcut_target_type"));
+    }
+    if (shortcut_target_type.empty()) {
+        shortcut_target_type = "file";
+    }
 
     if (kind == "link") {
         file->is_link = true;
@@ -328,7 +335,10 @@ std::shared_ptr<File> buildFile(const emscripten::val &entry) {
         if (target_path.empty()) {
             target_path = read_string(entry, "shortcut_target_path");
         }
-        register_pending_shortcut(file, target_path);
+        const bool targets_directory = shortcut_target_type == "directory";
+        if (!targets_directory) {
+            register_pending_shortcut(file, target_path);
+        }
     }
 
     return file;

--- a/src/components/desktop/Desktop.vue
+++ b/src/components/desktop/Desktop.vue
@@ -179,8 +179,14 @@ onMounted(() => {
   @apply stroke-accent-yellow-shadow;
 }
 
-.f path {
-  @apply stroke-accent-yellow-shadow;
+.f :deep(path),
+.f :deep(circle),
+.f :deep(ellipse),
+.f :deep(rect),
+.f :deep(line),
+.f :deep(polygon),
+.f :deep(polyline) {
+  @apply stroke-accent-yellow-shadow fill-accent-yellow-shadow;
 }
 
 

--- a/src/components/desktop/Desktop.vue
+++ b/src/components/desktop/Desktop.vue
@@ -28,8 +28,16 @@
             @dblclick="handleFileOpen(item)"
           >
             <Icon v-if="item.type === 'd'" :image="'directory'" class="d"/>
-            <Icon v-else-if="item.type === 'f' && !item.is_shortcut && !item.is_link" :image="'file'" class="d" />
-            <Icon v-else-if="item.type === 'f' && item.is_shortcut" :image="'shortcut'" class="d" />
+            <Icon
+              v-else-if="item.type === 'f' && item.is_shortcut && item.shortcutTargetsDirectory"
+              :image="'directory_shortcut'"
+              class="d"
+            />
+            <Icon
+              v-else-if="item.type === 'f' && item.is_shortcut"
+              :image="'shortcut'"
+              class="d"
+            />
             <Icon v-else-if="item.type === 'f' && item.is_link" :image="'browserLink'" class="d" />
             <div class="file-info">
               <span class="file-name">{{ item.name }}</span>
@@ -49,7 +57,7 @@ import MinimizedFileBar from '@/components/desktop/MinimizedFileBar.vue';
 import { createLoader } from '@/components/utilities/simulateLoading';
 import { initFilesystem as bootstrapFilesystem } from '@/components/utilities/initFilesystem';
 
-import { ref, toRaw, defineAsyncComponent, reactive, provide, onMounted } from 'vue';
+import { ref, defineAsyncComponent, reactive, provide, onMounted } from 'vue';
 
 const ContentWindow = defineAsyncComponent(() => import("@/components/windows/ContentWindow.vue"));
 const emit = defineEmits(['initialized', 'progress'])
@@ -59,6 +67,7 @@ import { storeToRefs } from 'pinia';
 import makeDirectoryItems from '@/components/utilities/makeDirectoryItems';
 import { makeFileItems } from '@/components/utilities/makeFileItems';
 import { openFile } from '@/components/utilities/openFile';
+import { openDirectoryInFileManager } from '@/components/utilities/openDirectory';
 import { useIsMobile } from "@/components/utilities/useIsMobile";
 
 const {isMobile} = useIsMobile()
@@ -67,7 +76,7 @@ const windowRefs = reactive({});
 provide('windowRefs', windowRefs);
 const desktopContents = ref([]);
 const appsStore = useAppsStore();
-const { openApps, openFiles, isAppOpen } = storeToRefs(appsStore);
+const { openApps, openFiles } = storeToRefs(appsStore);
 const fmId = 'file_manager'
 const browserId = 'browser'
 
@@ -83,14 +92,8 @@ const assignWindowRef = (id) => (el) => {
 
 
 const opendir = (item) => {
-  //TODO: FIX
-  
-  if (!isAppOpen(fmId)){
-    openApp(fmId);
-  }
-  const fm = windowRefs.find(app => app.id === fmId);
-  fm.chdir(item);
-}
+  openDirectoryInFileManager(item);
+};
 const getDesktopContents = () => {
   const desktop_ptr = SystemModule.get_desktop_dir_ptr();
   const files = SystemModule.list_files(desktop_ptr);
@@ -115,7 +118,7 @@ const getRandomPosition = (id) => {
 
 const handleFileOpen = (item) => {
   if (item.type === 'd') {
-    opendir(toRaw(item.object))
+    opendir(item.object)
   } else if (item.type === 'f' && item.is_link) {
     appsStore.openApp(browserId, { url: item.content })
   }else {

--- a/src/components/desktop/Desktop.vue
+++ b/src/components/desktop/Desktop.vue
@@ -186,7 +186,8 @@ onMounted(() => {
 .f :deep(line),
 .f :deep(polygon),
 .f :deep(polyline) {
-  @apply stroke-accent-yellow-shadow fill-accent-yellow-shadow;
+  @apply stroke-accent-yellow-shadow;
+  fill: none;
 }
 
 

--- a/src/components/desktop/Desktop.vue
+++ b/src/components/desktop/Desktop.vue
@@ -39,6 +39,11 @@
               class="d"
             />
             <Icon v-else-if="item.type === 'f' && item.is_link" :image="'browserLink'" class="d" />
+            <Icon
+              v-else-if="item.type === 'f'"
+              :image="'file'"
+              class="f"
+            />
             <div class="file-info">
               <span class="file-name">{{ item.name }}</span>
             </div>

--- a/src/components/utilities/initFilesystem.js
+++ b/src/components/utilities/initFilesystem.js
@@ -1,3 +1,5 @@
+import { registerShortcutManifest, rebuildShortcutPointerIndex } from '@/components/utilities/shortcutMetadata';
+
 const MANIFEST_QUERY = '*[_type == "portfolioManifest"][0]';
 
 function requireEnv(name) {
@@ -106,11 +108,13 @@ function hydrateManifestAssets(manifest) {
 export async function initFilesystem(manifestUrl) {
   const manifest = await (manifestUrl ? fetchManifestFromUrl(manifestUrl) : fetchManifestFromSanity());
   hydrateManifestAssets(manifest);
+  registerShortcutManifest(manifest);
 
   if (!window.SystemModule || typeof window.SystemModule.initFilesystem !== 'function') {
     throw new Error('SystemModule.initFilesystem is not available.');
   }
 
   window.SystemModule.initFilesystem(manifest);
+  rebuildShortcutPointerIndex();
   return manifest;
 }

--- a/src/components/utilities/makeFileItems.js
+++ b/src/components/utilities/makeFileItems.js
@@ -1,3 +1,5 @@
+import { getShortcutMetadataForFile } from '@/components/utilities/shortcutMetadata';
+
 function extractAssetUrl(file) {
     return (
         file?.assetUrl ||
@@ -32,6 +34,7 @@ function deriveContentMode(file) {
 function toFileObject(f) {
     const assetUrl = extractAssetUrl(f);
     const contentMode = deriveContentMode(f);
+    const shortcutMetadata = getShortcutMetadataForFile(f);
     return {
         object: f,
         type: "f",
@@ -42,7 +45,9 @@ function toFileObject(f) {
         assetUrl: assetUrl || (contentMode === 'url' ? f.content : null),
         asset: f.asset,
         is_shortcut: f.is_shortcut,
-        is_link: f.is_link
+        is_link: f.is_link,
+        shortcutTargetsDirectory: shortcutMetadata?.targetType === 'directory',
+        shortcutTargetPath: shortcutMetadata?.targetPath || null,
     };
 }
 

--- a/src/components/utilities/openDirectory.js
+++ b/src/components/utilities/openDirectory.js
@@ -1,0 +1,16 @@
+import { toRaw } from 'vue';
+import { useAppsStore } from '@/components/stores/apps';
+
+const FILE_MANAGER_APP_ID = 'file_manager';
+
+export function openDirectoryInFileManager(directoryPtr, options = {}) {
+  const appsStore = useAppsStore();
+  const normalizedPtr = directoryPtr ? toRaw(directoryPtr) : null;
+  const requestId = Date.now();
+
+  appsStore.openApp(FILE_MANAGER_APP_ID, {
+    targetDirectory: normalizedPtr,
+    targetPath: options.path ?? null,
+    requestId,
+  });
+}

--- a/src/components/utilities/openFile.js
+++ b/src/components/utilities/openFile.js
@@ -1,6 +1,7 @@
 import { toRaw } from "vue";
 import { makeFileItem } from "@/components/utilities/makeFileItems";
 import { useAppsStore } from "@/components/stores/apps";
+import { openDirectoryInFileManager } from "@/components/utilities/openDirectory";
 
 const BROWSER_APP_ID = 'browser';
 
@@ -17,6 +18,14 @@ export function openFile(item) {
   }
 
   if (item.is_shortcut) {
+    if (item.shortcutTargetsDirectory) {
+      if (item.shortcutTargetPath) {
+        openDirectoryInFileManager(null, { path: item.shortcutTargetPath });
+      } else {
+        alert("Shortcut target directory is missing or broken.");
+      }
+      return;
+    }
     const target = SystemModule.resolve_shortcut(toRaw(item.object));
     if (target) {
       appsStore.openFile(makeFileItem(target));

--- a/src/components/utilities/shortcutMetadata.js
+++ b/src/components/utilities/shortcutMetadata.js
@@ -162,16 +162,19 @@ export function findDirectoryByPath(path, moduleRef = window.SystemModule) {
   }
 
   for (const segment of segments) {
-    if (!segment) {
+    const normalizedSegment = typeof segment === 'string' ? segment.trim() : '';
+    if (!normalizedSegment) {
       continue;
     }
 
     const directories = moduleRef.list_directories(current);
     let match = null;
+    const segmentLower = normalizedSegment.toLowerCase();
     if (directories && typeof directories.size === 'function') {
       for (let i = 0; i < directories.size(); i++) {
         const child = directories.get(i);
-        if (child?.name === segment) {
+        const childName = child?.name;
+        if (childName && childName.toLowerCase?.() === segmentLower) {
           match = child;
           break;
         }

--- a/src/components/utilities/shortcutMetadata.js
+++ b/src/components/utilities/shortcutMetadata.js
@@ -1,0 +1,188 @@
+const manifestShortcutMap = new Map();
+const pointerShortcutMap = new Map();
+
+function sanitizeSegment(segment = '') {
+  if (typeof segment !== 'string') {
+    return '';
+  }
+  return segment.trim().replace(/^\/+|\/+$/g, '');
+}
+
+function buildChildPath(parentPath, childName) {
+  const child = sanitizeSegment(childName);
+  const parentIsRoot = !parentPath || parentPath === '/';
+  if (!child) {
+    return parentIsRoot ? '/' : parentPath;
+  }
+  if (parentIsRoot) {
+    return `/${child}`;
+  }
+  const parent = parentPath.replace(/\/+$/, '');
+  return `${parent}/${child}`;
+}
+
+function buildFilePath(parentPath, entry) {
+  const extension = typeof entry?.extension === 'string' && entry.extension.length
+    ? entry.extension.replace(/^\./, '')
+    : '';
+  const fileName = extension ? `${entry.name}.${extension}` : entry.name;
+  return buildChildPath(parentPath, fileName);
+}
+
+function walkManifestEntries(entries, parentPath) {
+  if (!Array.isArray(entries)) {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+
+    if (entry._type === 'portfolioEntry') {
+      if (entry.kind === 'shortcut') {
+        const shortcutPath = buildFilePath(parentPath, entry);
+        manifestShortcutMap.set(shortcutPath, {
+          targetPath: entry.shortcutTargetPath || entry.shortcut_target_path || null,
+          targetType: (entry.shortcutTargetType || entry.shortcut_target_type || 'file').toLowerCase(),
+        });
+      }
+      continue;
+    }
+
+    if (entry._type === 'remoteFolder') {
+      const nextPath = buildChildPath(parentPath, entry.name || '');
+      walkManifestEntries(entry.entries, nextPath);
+    }
+  }
+}
+
+export function registerShortcutManifest(manifest) {
+  manifestShortcutMap.clear();
+  pointerShortcutMap.clear();
+
+  if (!manifest || typeof manifest !== 'object') {
+    return;
+  }
+
+  walkManifestEntries(manifest.filesystem, '/');
+}
+
+function buildFileName(file) {
+  const extension = typeof file?.extension_abbr === 'string' && file.extension_abbr.length
+    ? `.${file.extension_abbr}`
+    : '';
+  return `${file?.name ?? ''}${extension}`;
+}
+
+function traverseFilesystem(moduleRef, dirPtr, currentPath) {
+  const files = moduleRef.list_files(dirPtr);
+  if (files && typeof files.size === 'function') {
+    for (let i = 0; i < files.size(); i++) {
+      const file = files.get(i);
+      if (!file) continue;
+      const filePath = buildChildPath(currentPath, buildFileName(file));
+      const metadata = manifestShortcutMap.get(filePath);
+      if (metadata) {
+        const ptr = file?.$$?.ptr;
+        if (ptr) {
+          pointerShortcutMap.set(ptr, metadata);
+        }
+      }
+    }
+  }
+
+  const directories = moduleRef.list_directories(dirPtr);
+  if (directories && typeof directories.size === 'function') {
+    for (let i = 0; i < directories.size(); i++) {
+      const child = directories.get(i);
+      if (!child) continue;
+      const childPath = buildChildPath(currentPath, child.name || '');
+      traverseFilesystem(moduleRef, child, childPath);
+    }
+  }
+}
+
+export function rebuildShortcutPointerIndex(moduleRef = window.SystemModule) {
+  pointerShortcutMap.clear();
+  if (!moduleRef || typeof moduleRef.get_root_dir_ptr !== 'function') {
+    return;
+  }
+
+  const root = moduleRef.get_root_dir_ptr();
+  if (!root) {
+    return;
+  }
+
+  traverseFilesystem(moduleRef, root, '/');
+}
+
+export function getShortcutMetadataForFile(file) {
+  const ptr = file?.$$?.ptr;
+  if (!ptr) {
+    return null;
+  }
+  return pointerShortcutMap.get(ptr) || null;
+}
+
+function splitPathSegments(path) {
+  if (typeof path !== 'string') {
+    return [];
+  }
+  return path.split('/').filter(Boolean);
+}
+
+export function findDirectoryByPath(path, moduleRef = window.SystemModule) {
+  if (!moduleRef || typeof path !== 'string') {
+    return null;
+  }
+
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  let current = null;
+  let segments = splitPathSegments(trimmed);
+
+  if (trimmed.startsWith('~/')) {
+    current = moduleRef.get_home_dir_ptr?.();
+    segments = segments.slice(1);
+  } else if (trimmed === '~') {
+    current = moduleRef.get_home_dir_ptr?.();
+    segments = [];
+  } else if (trimmed.startsWith('/')) {
+    current = moduleRef.get_root_dir_ptr?.();
+  } else {
+    current = moduleRef.get_root_dir_ptr?.();
+  }
+
+  if (!current) {
+    return null;
+  }
+
+  for (const segment of segments) {
+    if (!segment) {
+      continue;
+    }
+
+    const directories = moduleRef.list_directories(current);
+    let match = null;
+    if (directories && typeof directories.size === 'function') {
+      for (let i = 0; i < directories.size(); i++) {
+        const child = directories.get(i);
+        if (child?.name === segment) {
+          match = child;
+          break;
+        }
+      }
+    }
+
+    if (!match) {
+      return null;
+    }
+    current = match;
+  }
+
+  return current;
+}

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -49,6 +49,11 @@
           >
             <Icon v-if="item.type === 'd'" :image="'directory'" class="d"/>
             <Icon v-else-if="item.type === 'f' && !item.is_shortcut && !item.is_link" :image="'file'" class="d" />
+            <Icon
+              v-else-if="item.type === 'f' && item.is_shortcut && item.shortcutTargetsDirectory"
+              :image="'directory_shortcut'"
+              class="d"
+            />
             <Icon v-else-if="item.type === 'f' && item.is_shortcut" :image="'shortcut'" class="d" />
             <Icon
               v-else-if="item.type === 'f' && item.is_link"
@@ -68,16 +73,22 @@
 
 <script>
 import "@/assets/js/terminal/system";
-import { ref, onMounted, toRaw } from "vue";
+import { ref, onMounted, toRaw, watch } from "vue";
 import Icon from "@/components/desktop/Icon.vue";
-import { useAppsStore } from "@/components/stores/apps";
+import { findDirectoryByPath } from "@/components/utilities/shortcutMetadata";
 import makeDirectoryItems from "@/components/utilities/makeDirectoryItems";
 import {makeFileItems} from "@/components/utilities/makeFileItems";
 import { openFile } from '@/components/utilities/openFile'
 
 export default {
   components: { Icon },
-setup() {
+  props: {
+    args: {
+      type: Object,
+      default: null,
+    },
+  },
+setup(props) {
     // Reactive states
     const contents = ref([]);
     const disableBack = ref(true);
@@ -105,6 +116,46 @@ setup() {
       contents.value = getDirContents();
       syncButtonState();
     };
+
+    const tryNavigateToPath = (path) => {
+      if (!path) {
+        return false;
+      }
+
+      const resolved = findDirectoryByPath(path);
+      if (resolved) {
+        chdir(resolved);
+        return true;
+      }
+
+      return false;
+    };
+
+    const handleNavigationArgs = (args) => {
+      if (!args) {
+        return;
+      }
+
+      if (args.targetDirectory) {
+        chdir(toRaw(args.targetDirectory));
+        return;
+      }
+
+      if (args.targetPath) {
+        const success = tryNavigateToPath(args.targetPath);
+        if (!success) {
+          alert(`Unable to locate ${args.targetPath}. The shortcut may be out of date.`);
+        }
+      }
+    };
+
+    watch(
+      () => props.args,
+      (args) => {
+        handleNavigationArgs(args);
+      },
+      { immediate: true }
+    );
 
     const back = () => {
       SystemModule.cd_back();

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -96,15 +96,20 @@ setup(props) {
     const directoryTitle = ref("Directory");
     const activePtr = ref(null);
 
+    // Sync button states
+    const syncButtonState = () => {
+      disableBack.value = SystemModule.back_history_empty();
+      disableForward.value = SystemModule.forward_history_empty();
+    };
+
     // Fetch directory contents
     const getDirContents = () => {
       const files = SystemModule.list_files(SystemModule.get_cur_fs_dir());
       const directories = SystemModule.list_directories(SystemModule.get_cur_fs_dir());
       directoryTitle.value = SystemModule.get_cur_fs_dir().name;
 
-      //const contentsList = [];
       const contentsList = makeDirectoryItems(directories).concat(makeFileItems(files));
-      
+
       contentsList.sort((a, b) => a.name.localeCompare(b.name));
       return contentsList;
     };
@@ -167,12 +172,6 @@ setup(props) {
       SystemModule.cd_forward();
       contents.value = getDirContents();
       syncButtonState();
-    };
-
-    // Sync button states
-    const syncButtonState = () => {
-      disableBack.value = SystemModule.back_history_empty();
-      disableForward.value = SystemModule.forward_history_empty();
     };
 
     // On mounted, initialize contents and button states

--- a/studio-spicyos/schemaTypes/portfolioManifest.ts
+++ b/studio-spicyos/schemaTypes/portfolioManifest.ts
@@ -12,7 +12,7 @@ export const portfolioEntry = defineType({
     defineField({ name: 'asset', type: 'file' }),
     defineField({ name: 'shortcutTargetPath',
       type: 'string',
-      description: 'Absolute or ~-relative path to the file this shortcut should open.',
+      description: 'Absolute or ~-relative path to the file or folder this shortcut should open.',
       hidden: ({ parent }) => parent?.kind !== 'shortcut',
       validation: (Rule) => Rule.custom((value, context) => {
         if (context?.parent?.kind === 'shortcut' && !value) {
@@ -20,6 +20,20 @@ export const portfolioEntry = defineType({
         }
         return true;
       }),
+    }),
+    defineField({
+      name: 'shortcutTargetType',
+      type: 'string',
+      initialValue: 'file',
+      options: {
+        layout: 'radio',
+        list: [
+          { title: 'File', value: 'file' },
+          { title: 'Directory', value: 'directory' },
+        ],
+      },
+      description: 'Choose whether the shortcut opens a file directly or launches the File Manager in a folder.',
+      hidden: ({ parent }) => parent?.kind !== 'shortcut',
     }),
     defineField({ name: 'tags', type: 'array', of: [{ type: 'string' }] }),
     //defineField({ name: 'meta', type: 'object', fields: []}),


### PR DESCRIPTION
## Summary
- add shortcut metadata tracking so directory shortcuts can launch the File Manager instead of a file preview
- surface the directory shortcut icon across the desktop and File Manager UI while wiring up a helper to open directories directly
- document the new `shortcutTargetType` field, update the schema, and refresh the sample manifest entry

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b7b6ab58c832f8efa229405749a96)