### PR TITLE
Add blog routes and Sanity post schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@sanity/client": "^6.21.2",
     "@tailwindcss/vite": "^4.1.10",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
@@ -24,7 +25,8 @@
     "uuid": "^11.1.0",
     "vite-plugin-top-level-await": "^1.5.0",
     "vite-plugin-wasm": "^3.4.1",
-    "vue": "^3.5.17"
+    "vue": "^3.5.17",
+    "vue-router": "^4.4.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.4",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,44 +1,7 @@
 <template>
-  <!-- Fade transition around the loader -->
-  <transition name="fade">
-    <!-- Pass the `progress` prop and listen for skip -->
-    <LoadingScreen
-      v-if="loading"
-      :progress="progress"
-      @skip="loading = false"
-    />
-  </transition>
-
-  <Desktop
-    @initialized="onDesktopReady"
-    @progress="p => progress = p"
-  />
+  <RouterView />
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import LoadingScreen from '@/components/desktop/LoadingScreen.vue'
-import Desktop from '@/components/desktop/Desktop.vue'
-
-const loading = ref(true)
-const progress = ref(0)
-
-function onDesktopReady() {
-  // ensure bar can hit 100% and show the fade
-  setTimeout(() => {
-    loading.value = false
-  }, 200)
-}
+import { RouterView } from 'vue-router'
 </script>
-
-<style scoped>
-/* Fade transition */
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.5s ease;
-}
-.fade-enter-from,
-.fade-leave-to {
-  opacity: 0;
-}
-</style>

--- a/src/components/desktop/Desktop.vue
+++ b/src/components/desktop/Desktop.vue
@@ -86,6 +86,7 @@ const fmId = 'file_manager'
 const browserId = 'browser'
 
 const loader = createLoader(2, p => emit('progress', p))
+let systemModulePromise
 
 const assignWindowRef = (id) => (el) => {
   if (el) {
@@ -132,22 +133,45 @@ const handleFileOpen = (item) => {
 
 }
 
-onMounted(() => {
-  // initialize file system
-  SystemModule.onRuntimeInitialized = async () => {
-    loader.checkpoint()
-    try {
-      await bootstrapFilesystem();
-      console.log("SystemModule filesystem initialized from manifest.");
-    } catch (error) {
-      console.error("Failed to initialize filesystem", error);
-    }
-    desktopContents.value = getDesktopContents();
-    loader.checkpoint()
-  };
+const runDesktopBootstrap = async () => {
+  loader.checkpoint()
+  try {
+    await bootstrapFilesystem();
+    console.log("SystemModule filesystem initialized from manifest.");
+  } catch (error) {
+    console.error("Failed to initialize filesystem", error);
+  }
+  desktopContents.value = getDesktopContents();
+  loader.checkpoint()
+}
 
+const loadSystemModule = async () => {
+  if (!systemModulePromise) {
+    systemModulePromise = import('@/assets/js/terminal/system')
+  }
+  return systemModulePromise
+}
+
+const initializeSystemModule = async () => {
+  if (window.SystemModule?.calledRun) {
+    await runDesktopBootstrap()
+    return
+  }
+
+  window.SystemModule = window.SystemModule || {}
+
+  if (!window.SystemModule.onRuntimeInitialized) {
+    window.SystemModule.onRuntimeInitialized = async () => {
+      await runDesktopBootstrap()
+    }
+  }
+
+  await loadSystemModule()
+}
+
+onMounted(async () => {
+  await initializeSystemModule()
   loader.done.then(() => emit('initialized'))
-  
 })
 
 

--- a/src/components/desktop/Taskbar.vue
+++ b/src/components/desktop/Taskbar.vue
@@ -87,8 +87,9 @@ onMounted(() => {
 const windowRefs = inject('windowRefs');
 
 const openOrToggleApp = (id) => {
+  const appDefinition = appsStore.allApps.find(app => app.id === id);
   const app = windowRefs[id];
-  if (!app) return appsStore.openApp(id);
+  if (!app) return appsStore.openApp(id, appDefinition?.defaultArgs ?? null);
 
   const window = app.$refs.baseWindow;
   if (!window) return;

--- a/src/components/stores/apps.js
+++ b/src/components/stores/apps.js
@@ -16,6 +16,7 @@ export const useAppsStore = defineStore('apps', {
       { id: 'terminal', name: 'Terminal', image: 'terminal', shared: true, minWidth: getIsMobile().value ? 400 : 495},
       { id: 'file_manager', name: 'File Manager', image: 'directory', shared: true},
       { id: 'browser', name: 'Browser', image: 'browser', shared: true},
+      { id: 'blog', name: 'Blog', image: 'browser', shared: true, defaultArgs: { url: '/blog' }},
     ],
 
     openApps: [], // [{ id: 'terminal', zIndex: 1, ... }]

--- a/src/components/utilities/blogQueries.js
+++ b/src/components/utilities/blogQueries.js
@@ -1,0 +1,27 @@
+import {sanityClient} from './sanityClient'
+
+export async function getAllPosts() {
+  const query = `*[_type == "post"] | order(publishedAt desc){
+    title,
+    "slug": slug.current,
+    excerpt,
+    coverImage,
+    publishedAt
+  }`
+
+  return sanityClient.fetch(query)
+}
+
+export async function getPostBySlug(slug) {
+  const query = `*[_type == "post" && slug.current == $slug][0]{
+    title,
+    "slug": slug.current,
+    excerpt,
+    coverImage,
+    publishedAt,
+    tags,
+    content
+  }`
+
+  return sanityClient.fetch(query, {slug})
+}

--- a/src/components/utilities/sanityClient.js
+++ b/src/components/utilities/sanityClient.js
@@ -1,0 +1,22 @@
+import {createClient} from '@sanity/client'
+
+function requireEnv(name) {
+  const value = import.meta.env?.[name]
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+  return value
+}
+
+const projectId = requireEnv('VITE_SANITY_PROJECT_ID')
+const dataset = requireEnv('VITE_SANITY_DATASET')
+const apiVersion = requireEnv('VITE_SANITY_API_VERSION')
+
+export const sanityClient = createClient({
+  projectId,
+  dataset,
+  apiVersion,
+  useCdn: true,
+})
+
+export const imageBuilderBase = `https://cdn.sanity.io/images/${projectId}/${dataset}/`

--- a/src/components/utilities/sanityImages.js
+++ b/src/components/utilities/sanityImages.js
@@ -1,0 +1,18 @@
+import { imageBuilderBase } from './sanityClient'
+
+export function buildImageUrlFromRef(ref) {
+  if (!ref) return null
+
+  const imageMatch = /^image-([^-]+)-(\d+x\d+)-([a-zA-Z0-9]+)$/.exec(ref)
+  if (!imageMatch) {
+    return null
+  }
+
+  const [, hash, dimensions, extension] = imageMatch
+  return `${imageBuilderBase}${hash}-${dimensions}.${extension}`
+}
+
+export function getCoverImageUrl(imageField) {
+  if (!imageField || typeof imageField !== 'object') return null
+  return buildImageUrlFromRef(imageField.asset?._ref)
+}

--- a/src/components/windows/ContentWindow.vue
+++ b/src/components/windows/ContentWindow.vue
@@ -48,8 +48,8 @@ const contentComponent = computed(() => {
   } else if (props.id === "file_manager") {
     title.value = "File Manager";
     return FileManagerView;
-  }else if (props.id === "browser") {
-    title.value = "Browser";
+  } else if (props.id === "browser" || props.id === "blog") {
+    title.value = props.id === "blog" ? "Blog" : "Browser";
     return BrowserView;
   }
   return null;

--- a/src/main.js
+++ b/src/main.js
@@ -1,15 +1,14 @@
 import { createApp } from 'vue'
-import { createPinia } from 'pinia';
+import { createPinia } from 'pinia'
+import { router } from '@/router'
 import '../node_modules/augmented-ui/augmented-ui.min.css'
 import './style.css'
-import '@/assets/js/terminal/system';
-import App from '@/App.vue';
+import '@/assets/js/terminal/system'
+import App from '@/App.vue'
 
+const app = createApp(App)
+const pinia = createPinia()
 
-const app = createApp(App);
-const pinia = createPinia();
-
-app.use(pinia); // Register Pinia
-app.mount('#app'); // Mount the app
-
-
+app.use(pinia)
+app.use(router)
+app.mount('#app')

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,6 @@ import { createPinia } from 'pinia'
 import { router } from '@/router'
 import '../node_modules/augmented-ui/augmented-ui.min.css'
 import './style.css'
-import '@/assets/js/terminal/system'
 import App from '@/App.vue'
 
 const app = createApp(App)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,25 @@
+import {createRouter, createWebHistory} from 'vue-router'
+
+const routes = [
+  {
+    path: '/',
+    name: 'os',
+    component: () => import('@/routes/os/index.vue'),
+  },
+  {
+    path: '/blog',
+    name: 'blog-index',
+    component: () => import('@/routes/blog/index.vue'),
+  },
+  {
+    path: '/blog/:slug',
+    name: 'blog-post',
+    component: () => import('@/routes/blog/[slug].vue'),
+    props: true,
+  },
+]
+
+export const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})

--- a/src/routes/blog/[slug].vue
+++ b/src/routes/blog/[slug].vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="blog-shell">
+    <header class="blog-header">
+      <div>
+        <p class="eyebrow">SpicyOS / Blog</p>
+        <h1 class="headline">{{ post?.title || 'Loading…' }}</h1>
+        <p class="lede">{{ formatDate(post?.publishedAt) }}</p>
+        <div v-if="post?.tags?.length" class="tags">
+          <span v-for="tag in post.tags" :key="tag" class="tag">{{ tag }}</span>
+        </div>
+      </div>
+      <RouterLink class="back-link" to="/blog">Back to Blog</RouterLink>
+    </header>
+
+    <div v-if="loading" class="loading-state">
+      <div class="spinner" />
+      <p>Decrypting entry…</p>
+    </div>
+
+    <div v-else-if="error" class="error-state">
+      <p>{{ error }}</p>
+      <RouterLink class="back-link" to="/blog">Return to index</RouterLink>
+    </div>
+
+    <div v-else-if="post" class="post-body">
+      <div v-if="coverUrl(post.coverImage)" class="cover-wrapper">
+        <img :src="coverUrl(post.coverImage)" :alt="post.title" class="cover" />
+      </div>
+      <article class="prose" v-html="renderedMarkdown" />
+    </div>
+
+    <div v-else class="empty-state">
+      <p>Post not found.</p>
+      <RouterLink class="back-link" to="/blog">Return to index</RouterLink>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { marked } from 'marked'
+import { getPostBySlug } from '@/components/utilities/blogQueries'
+import { getCoverImageUrl } from '@/components/utilities/sanityImages'
+
+const props = defineProps({
+  slug: {
+    type: String,
+    required: true,
+  },
+})
+
+const post = ref(null)
+const loading = ref(true)
+const error = ref('')
+
+const formatDate = (value) => {
+  if (!value) return 'Unscheduled'
+  return new Intl.DateTimeFormat('en', { year: 'numeric', month: 'long', day: 'numeric' }).format(new Date(value))
+}
+
+const coverUrl = (image) => getCoverImageUrl(image)
+
+const renderedMarkdown = computed(() => {
+  if (!post.value?.content) return ''
+  return marked.parse(post.value.content)
+})
+
+onMounted(async () => {
+  try {
+    post.value = await getPostBySlug(props.slug)
+  } catch (err) {
+    error.value = 'Unable to load this post right now.'
+    console.error(err)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+@reference '../../style.css';
+
+.blog-shell {
+  @apply min-h-dvh bg-primary-bg text-white p-8 flex flex-col gap-8;
+}
+
+.blog-header {
+  @apply flex flex-col md:flex-row md:items-center md:justify-between gap-4 border-b border-primary-glow pb-4;
+}
+
+.eyebrow {
+  @apply uppercase tracking-widest text-xs text-accent-yellow-shadow;
+}
+
+.headline {
+  @apply text-4xl font-semibold mt-1;
+}
+
+.lede {
+  @apply text-gray-300;
+}
+
+.tags {
+  @apply flex flex-wrap gap-2 mt-2;
+}
+
+.tag {
+  @apply text-xs uppercase tracking-wide px-2 py-1 rounded-full bg-primary-shadow border border-primary-glow;
+}
+
+.back-link {
+  @apply text-sm text-accent-yellow-shadow underline hover:text-alerts-base;
+}
+
+.loading-state,
+.empty-state {
+  @apply flex flex-col items-center gap-3 text-gray-300;
+}
+
+.spinner {
+  @apply h-10 w-10 border-2 border-primary-glow border-t-alerts-base rounded-full animate-spin;
+}
+
+.error-state {
+  @apply bg-alerts-base/10 border border-alerts-base text-alerts-base px-4 py-3 rounded;
+}
+
+.post-body {
+  @apply flex flex-col gap-6;
+}
+
+.cover-wrapper {
+  @apply h-80 overflow-hidden rounded-lg border border-primary-glow;
+}
+
+.cover {
+  @apply object-cover w-full h-full;
+}
+
+.prose {
+  @apply bg-primary-shadow/40 border border-primary-glow p-6 rounded-lg leading-relaxed text-gray-100;
+}
+
+.prose :deep(a) {
+  @apply text-accent-yellow-shadow underline;
+}
+
+.prose :deep(code) {
+  @apply bg-primary-shadow px-1 py-0.5 rounded;
+}
+
+.prose :deep(h1),
+.prose :deep(h2),
+.prose :deep(h3),
+.prose :deep(h4) {
+  @apply text-white mt-6 mb-3 font-semibold;
+}
+
+.prose :deep(p) {
+  @apply mb-4;
+}
+</style>

--- a/src/routes/blog/index.vue
+++ b/src/routes/blog/index.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="blog-shell">
+    <header class="blog-header">
+      <div>
+        <p class="eyebrow">SpicyOS / Blog</p>
+        <h1 class="headline">Signal Log</h1>
+        <p class="lede">Dispatches, release notes, and thoughts from the cockpit.</p>
+      </div>
+      <RouterLink class="back-link" to="/">Back to SpicyOS</RouterLink>
+    </header>
+
+    <div v-if="error" class="error-state">
+      <p>{{ error }}</p>
+    </div>
+
+    <div class="posts-grid" v-else-if="!loading && posts.length">
+      <article
+        v-for="post in posts"
+        :key="post.slug"
+        class="post-card"
+      >
+        <RouterLink :to="`/blog/${post.slug}`" class="card-link">
+          <div v-if="coverUrl(post.coverImage)" class="cover-wrapper">
+            <img :src="coverUrl(post.coverImage)" :alt="post.title" class="cover" />
+          </div>
+          <div class="post-meta">
+            <p class="post-date">{{ formatDate(post.publishedAt) }}</p>
+            <h2 class="post-title">{{ post.title }}</h2>
+            <p class="post-excerpt">{{ post.excerpt }}</p>
+          </div>
+        </RouterLink>
+      </article>
+    </div>
+
+    <div v-else-if="!loading" class="empty-state">
+      <p>No posts yet. Check back soon.</p>
+    </div>
+
+    <div v-else class="loading-state">
+      <div class="spinner" />
+      <p>Loading transmissions…</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import { getAllPosts } from '@/components/utilities/blogQueries'
+import { getCoverImageUrl } from '@/components/utilities/sanityImages'
+
+const posts = ref([])
+const loading = ref(true)
+const error = ref('')
+
+const formatDate = (value) => {
+  if (!value) return 'Unscheduled'
+  return new Intl.DateTimeFormat('en', { year: 'numeric', month: 'short', day: 'numeric' }).format(new Date(value))
+}
+
+const coverUrl = (image) => getCoverImageUrl(image)
+
+onMounted(async () => {
+  try {
+    posts.value = await getAllPosts()
+  } catch (err) {
+    error.value = 'Unable to fetch posts right now.'
+    console.error(err)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+@reference '../../style.css';
+
+.blog-shell {
+  @apply min-h-dvh bg-primary-bg text-white p-8 flex flex-col gap-8;
+}
+
+.blog-header {
+  @apply flex flex-col md:flex-row md:items-center md:justify-between gap-4 border-b border-primary-glow pb-4;
+}
+
+.eyebrow {
+  @apply uppercase tracking-widest text-xs text-accent-yellow-shadow;
+}
+
+.headline {
+  @apply text-4xl font-semibold mt-1;
+}
+
+.lede {
+  @apply text-gray-300;
+}
+
+.back-link {
+  @apply text-sm text-accent-yellow-shadow underline hover:text-alerts-base;
+}
+
+.posts-grid {
+  @apply grid gap-6 md:grid-cols-2;
+}
+
+.post-card {
+  @apply bg-primary-shadow/60 border border-primary-glow rounded-lg overflow-hidden hover:border-alerts-base transition-colors;
+}
+
+.card-link {
+  @apply flex flex-col h-full no-underline text-inherit;
+}
+
+.cover-wrapper {
+  @apply h-52 overflow-hidden;
+}
+
+.cover {
+  @apply object-cover w-full h-full;
+}
+
+.post-meta {
+  @apply p-4 flex-1 flex flex-col gap-2;
+}
+
+.post-date {
+  @apply text-xs uppercase tracking-wide text-accent-yellow-shadow;
+}
+
+.post-title {
+  @apply text-xl font-semibold;
+}
+
+.post-excerpt {
+  @apply text-gray-300 line-clamp-3;
+}
+
+.loading-state,
+.empty-state {
+  @apply flex flex-col items-center gap-3 text-gray-300;
+}
+
+.error-state {
+  @apply bg-alerts-base/10 border border-alerts-base text-alerts-base px-4 py-3 rounded;
+}
+
+.spinner {
+  @apply h-10 w-10 border-2 border-primary-glow border-t-alerts-base rounded-full animate-spin;
+}
+</style>

--- a/src/routes/os/index.vue
+++ b/src/routes/os/index.vue
@@ -1,0 +1,41 @@
+<template>
+  <transition name="fade">
+    <LoadingScreen
+      v-if="loading"
+      :progress="progress"
+      @skip="loading = false"
+    />
+  </transition>
+
+  <Desktop
+    @initialized="onDesktopReady"
+    @progress="(p) => (progress = p)"
+  />
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import Desktop from '@/components/desktop/Desktop.vue'
+import LoadingScreen from '@/components/desktop/LoadingScreen.vue'
+
+const loading = ref(true)
+const progress = ref(0)
+
+function onDesktopReady() {
+  setTimeout(() => {
+    loading.value = false
+  }, 200)
+}
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.5s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/studio-spicyos/schemaTypes/index.ts
+++ b/studio-spicyos/schemaTypes/index.ts
@@ -2,5 +2,6 @@ import portfolioManifest, {
   portfolioEntry,
   remoteFolder
 } from './portfolioManifest';
+import post from './post';
 
-export const schemaTypes = [remoteFolder, portfolioEntry, portfolioManifest]
+export const schemaTypes = [remoteFolder, portfolioEntry, portfolioManifest, post]

--- a/studio-spicyos/schemaTypes/post.ts
+++ b/studio-spicyos/schemaTypes/post.ts
@@ -1,0 +1,55 @@
+import {defineField, defineType} from 'sanity'
+
+const post = defineType({
+  name: 'post',
+  title: 'Post',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'publishedAt',
+      title: 'Published at',
+      type: 'datetime',
+    }),
+    defineField({
+      name: 'excerpt',
+      title: 'Excerpt',
+      type: 'text',
+    }),
+    defineField({
+      name: 'tags',
+      title: 'Tags',
+      type: 'array',
+      of: [{type: 'string'}],
+    }),
+    defineField({
+      name: 'coverImage',
+      title: 'Cover image',
+      type: 'image',
+      options: {hotspot: true},
+    }),
+    defineField({
+      name: 'content',
+      title: 'Content',
+      description: 'Markdown-compatible body',
+      type: 'text',
+    }),
+  ],
+});
+
+export default post;


### PR DESCRIPTION
## Summary
- add a Sanity v3 `post` schema and utilities for fetching blog content
- introduce Vue Router-driven blog index and post reader pages with markdown rendering
- wire the faux OS browser/taskbar to open the blog and route between OS and blog views

## Testing
- Not run (npm install blocked by registry 403, so build/tests could not be executed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69309caf8d14832fbcca4b8cfc236acf)