### PR TITLE
feat: add HTML file rendering and fix heading/emoji sizing

### DIFF
--- a/src/components/utilities/fileLoader.js
+++ b/src/components/utilities/fileLoader.js
@@ -97,6 +97,9 @@ function determineRenderMode(mimeType = '', extension = '') {
   if (normalizedExt === 'md' || normalizedMime === 'text/markdown') {
     return 'markdown';
   }
+  if (normalizedExt === 'html' || normalizedExt === 'htm' || normalizedMime === 'text/html') {
+    return 'html';
+  }
   if (normalizedMime.startsWith('image/')) {
     return 'image';
   }
@@ -119,7 +122,7 @@ function determineRenderMode(mimeType = '', extension = '') {
 }
 
 function isTextRenderMode(renderMode) {
-  return renderMode === 'text' || renderMode === 'markdown';
+  return renderMode === 'text' || renderMode === 'markdown' || renderMode === 'html';
 }
 
 function detectContentMode(entry = {}) {

--- a/src/components/views/FileViewerView.vue
+++ b/src/components/views/FileViewerView.vue
@@ -17,6 +17,10 @@
         <div :id="id" class="page-content" v-html="renderer.content"></div>
       </div>
 
+      <div v-else-if="renderer.mode === 'html'" class="page-content-container">
+        <div class="page-content html-content" v-html="renderer.content"></div>
+      </div>
+
       <img v-else-if="renderer.mode === 'image'" :src="renderer.source" alt="Image preview" class="image-preview" />
       <video v-else-if="renderer.mode === 'video'" :src="renderer.source" controls class="video-preview"></video>
       <audio v-else-if="renderer.mode === 'audio'" :src="renderer.source" controls class="audio-preview"></audio>
@@ -128,6 +132,10 @@ function renderFile(file) {
     return { mode: 'markdown', content: renderMarkdownContent(file.rawData) };
   }
 
+  if (file.renderMode === 'html') {
+    return { mode: 'html', content: typeof file.rawData === 'string' ? file.rawData : '' };
+  }
+
   if (file.renderMode === 'text') {
     return { mode: 'text', content: formatTextContent(file.rawData) };
   }
@@ -231,6 +239,11 @@ onBeforeUnmount(() => {
   @apply text-red-500 font-bold;
 }
 
+.html-content {
+  filter: none;
+  padding: 0;
+}
+
 .page-content ul {
   @apply list-disc pl-6 mb-4;
 }
@@ -244,7 +257,7 @@ onBeforeUnmount(() => {
 }
 
 .page-content h1 {
-  @apply mb-5;
+  @apply text-2xl font-bold text-primary-base mb-5;
 }
 
 .page-content h2 {


### PR DESCRIPTION
- Add 'html' render mode to fileLoader.js so .html files render as HTML instead of falling through to plain text
- Add html-content rendering in FileViewerView.vue using v-html without the newline→<br> transformation that corrupts markup
- Fix h1 in .page-content having no font-size (browser default 2em made headings and inline emojis oversized)