### PR TITLE
feat: centralize theming, fix brightness tint, add browser forward button

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
       minWidth: window.innerWidth,
       scale: 1.0,
       scaleMobile: 1.0,
-      color: "#9c173b",
-      backgroundColor: "#17001d",
+      color: "#ff2e76",
+      backgroundColor: "#2e003a",
     });
   });
     </script>

--- a/src/assets/icons/browserForward.svg
+++ b/src/assets/icons/browserForward.svg
@@ -1,0 +1,3 @@
+<svg class="browser-icon" height="100%" width="100%" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <polyline points="9 18 15 12 9 6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/desktop/Taskbar.vue
+++ b/src/components/desktop/Taskbar.vue
@@ -141,7 +141,7 @@ const openOrToggleApp = (id) => {
 
 /* Use currentColor to inherit fill color dynamically */
 .icon-svg:hover {
-  filter: drop-shadow(0 0 5px #0098db) drop-shadow(0 0 10px #0098db);
+  filter: drop-shadow(0 0 5px var(--color-alerts-base)) drop-shadow(0 0 10px var(--color-alerts-base));
 }
 
 #taskbar {

--- a/src/components/utilities/openFile.js
+++ b/src/components/utilities/openFile.js
@@ -4,6 +4,21 @@ import { useAppsStore } from "@/components/stores/apps";
 import { openDirectoryInFileManager } from "@/components/utilities/openDirectory";
 
 const BROWSER_APP_ID = 'browser';
+const HTML_EXTENSIONS = new Set(['html', 'htm']);
+
+function openInBrowser(item) {
+  const appsStore = useAppsStore();
+  let url = item.assetUrl || (item.contentMode === 'url' ? item.content : null);
+  if (!url && item.content) {
+    const blob = new Blob([item.content], { type: 'text/html' });
+    url = URL.createObjectURL(blob);
+  }
+  if (url) {
+    appsStore.openApp(BROWSER_APP_ID, { url });
+  } else {
+    console.warn('Attempted to open HTML file without content.', item);
+  }
+}
 
 export function openFile(item) {
   const appsStore = useAppsStore();
@@ -28,10 +43,17 @@ export function openFile(item) {
     }
     const target = SystemModule.resolve_shortcut(toRaw(item.object));
     if (target) {
-      appsStore.openFile(makeFileItem(target));
+      const resolvedItem = makeFileItem(target);
+      if (HTML_EXTENSIONS.has(resolvedItem.exten?.toLowerCase())) {
+        openInBrowser(resolvedItem);
+      } else {
+        appsStore.openFile(resolvedItem);
+      }
     } else {
       alert("Shortcut target is missing or broken.");
     }
+  } else if (HTML_EXTENSIONS.has(item.exten?.toLowerCase())) {
+    openInBrowser(item);
   } else {
     appsStore.openFile(item);
   }

--- a/src/components/views/BrowserView.vue
+++ b/src/components/views/BrowserView.vue
@@ -9,6 +9,11 @@
           <BrowserBackIcon class="browser-icon"/>
         </button>
 
+        <!-- Forward button -->
+        <button class="browser-button" @click="goForward" :disabled="!canGoForward">
+          <BrowserForwardIcon class="browser-icon"/>
+        </button>
+
         <!-- Reload button -->
         <button class="browser-button" @click="reloadPage">
           <BrowserRefreshIcon class="browser-icon refresh"/>
@@ -38,6 +43,7 @@
 import { computed, ref, useTemplateRef, watch } from 'vue';
 import { extractAndDecodeBase64 } from '@/components/utilities/decode'
 import BrowserBackIcon from '@/assets/icons/browserBack.svg'
+import BrowserForwardIcon from '@/assets/icons/browserForward.svg'
 import BrowserNewTabIcon from '@/assets/icons/browserNewTab.svg'
 import BrowserRefreshIcon from '@/assets/icons/browserRefresh.svg'
 
@@ -90,11 +96,17 @@ watch(
 );
 
 const canGoBack = computed(() => historyIndex.value > 0);
+const canGoForward = computed(() => historyIndex.value < history.value.length - 1);
 
 const goBack = () => {
   if (historyIndex.value <= 0) return;
-
   historyIndex.value -= 1;
+  currentUrl.value = history.value[historyIndex.value];
+};
+
+const goForward = () => {
+  if (historyIndex.value >= history.value.length - 1) return;
+  historyIndex.value += 1;
   currentUrl.value = history.value[historyIndex.value];
 };
 
@@ -123,14 +135,14 @@ const reloadPage = () => {
 }
 
 .browser-icon {
-  filter: drop-shadow(0 0 1px #ff0546) drop-shadow(0 0 5px #ff0546);
+  filter: drop-shadow(0 0 1px var(--color-primary-accent-bright)) drop-shadow(0 0 5px var(--color-primary-accent-bright));
   cursor: pointer;
   height: 20px;
   width: 20px;
 }
 
 .browser-icon:hover {
-  filter: drop-shadow(0 0 5px #0098db) drop-shadow(0 0 10px #0098db);
+  filter: drop-shadow(0 0 5px var(--color-alerts-base)) drop-shadow(0 0 10px var(--color-alerts-base));
 }
 
 .browser-icon:hover circle,

--- a/src/components/views/FileManagerView.vue
+++ b/src/components/views/FileManagerView.vue
@@ -270,7 +270,7 @@ setup(props) {
 }
 
 .nav-button:hover {
-  filter: drop-shadow(0 0 5px #0098db) drop-shadow(0 0 10px #0098db);
+  filter: drop-shadow(0 0 5px var(--color-alerts-base)) drop-shadow(0 0 10px var(--color-alerts-base));
   @apply text-alerts-base;
 }
 

--- a/src/components/views/FileViewerView.vue
+++ b/src/components/views/FileViewerView.vue
@@ -213,7 +213,6 @@ onBeforeUnmount(() => {
 
 .page-content {
   @apply relative text-primary-dark-base p-8 h-full overflow-auto;
-  filter: brightness(0.5);
   line-height: 1.8rem;
 }
 
@@ -221,13 +220,11 @@ onBeforeUnmount(() => {
   @apply w-auto h-auto max-w-full max-h-full p-3;
   object-fit: contain;
   display: block;
-  filter: brightness(0.5);
 }
 
 .video-preview,
 .audio-preview {
   @apply w-full max-w-4xl;
-  filter: brightness(0.5);
 }
 
 .pdf-frame {
@@ -240,7 +237,6 @@ onBeforeUnmount(() => {
 }
 
 .html-content {
-  filter: none;
   padding: 0;
 }
 

--- a/src/components/windows/BaseWindow/BaseWindow.vue
+++ b/src/components/windows/BaseWindow/BaseWindow.vue
@@ -363,7 +363,7 @@ defineExpose({
 
 .base-window {
   @apply flex overflow-hidden max-h-full max-w-full fixed;
-  --aug-border-bg: #ff0546;
+  --aug-border-bg: var(--color-primary-accent-bright);
   --aug-border-opacity: 0.25;
 }
 

--- a/src/components/windows/BaseWindow/TitleBar.vue
+++ b/src/components/windows/BaseWindow/TitleBar.vue
@@ -100,12 +100,12 @@ const { isMobile } = useIsMobile();
 }
 
 .title-icon {
-  filter: drop-shadow(0 0 1px #ff0546) drop-shadow(0 0 5px #ff0546);
+  filter: drop-shadow(0 0 1px var(--color-primary-accent-bright)) drop-shadow(0 0 5px var(--color-primary-accent-bright));
 }
 
 
 .title-icon:hover {
-  filter: drop-shadow(0 0 5px #0098db) drop-shadow(0 0 10px #0098db);
+  filter: drop-shadow(0 0 5px var(--color-alerts-base)) drop-shadow(0 0 10px var(--color-alerts-base));
 }
 .title-icon:hover circle,
 .title-icon:hover line,

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia';
-import '../node_modules/augmented-ui/augmented-ui.min.css'
+import 'augmented-ui/augmented-ui.min.css'
 import './style.css'
 import '@/assets/js/terminal/system';
 import App from '@/App.vue';

--- a/src/style.css
+++ b/src/style.css
@@ -16,23 +16,23 @@
   --spacing-full: 100%;
 
   /* Primary Colors */
-  --color-primary-base: #660f31;
-  --color-primary-shadow: #450327;
-  --color-primary-bg: #835b86;
-  --color-primary-accent-light: #9c173b;
-  --color-primary-accent-bright: #ff0546;
-  --color-primary-dark-base: #270022;
-  --color-primary-dark-shadow: #17001d;
-  --color-primary-dark-deep: #09010d;
+  --color-primary-base: #cc1e62;
+  --color-primary-shadow: #8a064e;
+  --color-primary-bg: #ffb6ff;
+  --color-primary-accent-light: #ff2e76;
+  --color-primary-accent-bright: #ff0a8c;
+  --color-primary-dark-base: #4e0044;
+  --color-primary-dark-shadow: #2e003a;
+  --color-primary-dark-deep: #12021a;
 
   /* Alerts */
-  --color-alerts-base: #0098db;
-  --color-alerts-accent: #0ce6f2;
-  --color-alerts-shadow: #1e579c;
+  --color-alerts-base: #00ffff;
+  --color-alerts-accent: #18ffff;
+  --color-alerts-shadow: #3caeff;
 
   /* Accent Yellow */
-  --color-accent-yellow-base: #fee801;
-  --color-accent-yellow-shadow: #9c8e00;
+  --color-accent-yellow-base: #ffff02;
+  --color-accent-yellow-shadow: #ffff00;
 }
 
 :root {
@@ -42,7 +42,7 @@
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  background-color: #484848;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -60,7 +60,6 @@ a:hover {
 }
 
 body {
-  filter: brightness(2);
   margin: 0;
   padding: 0;
   display: flex;
@@ -81,7 +80,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #343434;
   cursor: pointer;
   transition: border-color 0.25s;
 }


### PR DESCRIPTION
## Summary

- **Remove `filter: brightness(2)` from `body`** — this was blowing out images, videos, and iframes. All `@theme` color tokens and the Vanta.NET background config have been updated with the mathematically equivalent brightened values (each RGB channel × 2, capped at 255) so the visual appearance is preserved without the side effects.
- **Centralize theme colors** — hardcoded hex values in `drop-shadow` filters across `Taskbar`, `TitleBar`, `BrowserView`, `FileManagerView`, and `BaseWindow` replaced with `var(--color-*)` references pointing to the single `@theme` source in `style.css`.
- **Fix `augmented-ui` import** — changed `../node_modules/augmented-ui/...` to `augmented-ui/...` so Vite resolves it correctly (the relative path broke in the worktree context).
- **HTML files open in built-in browser** — `.html`/`.htm` files now route to the browser app (via URL or a Blob URL for inline content) instead of opening in FileViewer, matching the behavior of link files.
- **Browser forward button** — added `goForward` / `canGoForward` logic and a new `browserForward.svg` icon; the forward button sits between back and reload and disables when there's nowhere to go forward to.

## Test plan

- [ ] Open an image or video file — should display at normal brightness, no blowout
- [ ] Verify desktop background (Vanta.NET) looks as bright as it did with the old filter
- [ ] Open an `.html` file from the filesystem — should load in the built-in browser
- [ ] Navigate a few pages in the browser, go back, then use the new forward button
- [ ] Forward button should be disabled when at the end of history
- [ ] Verify drop-shadow glow colors on icons/title bars still match the theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)